### PR TITLE
Fixes and improvements for new Auto Optimizer

### DIFF
--- a/libobs/media-io/audio-io.c
+++ b/libobs/media-io/audio-io.c
@@ -274,8 +274,8 @@ static void input_and_output(struct audio_output *audio, uint64_t audio_time,
 		/* clamps audio data to -1.0..1.0 */
 		clamp_audio_output(audio, bytes, canvas);
 
-		/* Route with the loop-local identity: another audio_t thread may
-		 * update the legacy global rendering context concurrently. */
+		/* Pass the canvas explicitly because another audio output thread can
+		 * change the current audio rendering canvas concurrently. */
 		for (size_t i = 0; i < MAX_AUDIO_MIXES; i++)
 			do_audio_output(audio, i, new_ts, AUDIO_OUTPUT_FRAMES,
 					canvas);

--- a/libobs/media-io/audio-io.c
+++ b/libobs/media-io/audio-io.c
@@ -114,45 +114,23 @@ static bool resample_audio_output(struct audio_input *input, struct audio_data *
 	return success;
 }
 
-struct audio_mix_buffer *get_audio_mix(struct audio_output *audio,
-				       size_t mix_idx, void *canvas)
+static void do_audio_output(struct audio_output *audio, size_t mix_idx, uint64_t timestamp, uint32_t frames,
+			    struct audio_mix_outputs *outputs)
 {
-	struct audio_mix_buffer *ret = NULL;
-	for (size_t canvas_idx = 0; canvas_idx < audio->mixes_outputs.num;
-	     canvas_idx++) {
-		struct audio_mix_outputs *output_mixes =
-			audio->mixes_outputs.array + canvas_idx;
-		if (ret == NULL || output_mixes->canvas == canvas) {
-			ret = &output_mixes->buffers[mix_idx];
-		}
-	}
-	return ret;
-}
-
-static void do_audio_output(struct audio_output *audio, size_t mix_idx,
-			    uint64_t timestamp, uint32_t frames, void *canvas)
-{
-	struct audio_mix_buffer *output_mix =
-		get_audio_mix(audio, mix_idx, canvas);
+	struct audio_mix_buffer *output_mix = &outputs->buffers[mix_idx];
 	struct audio_mix *mix = &audio->mixes[mix_idx];
 	struct audio_data data;
 
-	if (mix == NULL || output_mix == NULL) {
-		return;
-	}
 	pthread_mutex_lock(&audio->input_mutex);
 	for (size_t input_idx = mix->inputs.num; input_idx > 0; input_idx--) {
 		struct audio_input *input = mix->inputs.array + (input_idx - 1);
 
 		struct obs_encoder *encoder = input->param;
-		if (encoder && encoder->video &&
-		    encoder->video->canvas_ovi != canvas) {
+		if (encoder && encoder->video && encoder->video->canvas_ovi != outputs->canvas) {
 			continue;
 		}
-		float(*buf)[AUDIO_OUTPUT_FRAMES] =
-			input->conversion.allow_clipping
-				? mix->buffer_unclamped.data
-				: output_mix->data;
+		float(*buf)[AUDIO_OUTPUT_FRAMES] = input->conversion.allow_clipping ? mix->buffer_unclamped.data
+										    : output_mix->data;
 
 		for (size_t i = 0; i < audio->planes; i++)
 			data.data[i] = (uint8_t *)buf[i];
@@ -167,14 +145,12 @@ static void do_audio_output(struct audio_output *audio, size_t mix_idx,
 	pthread_mutex_unlock(&audio->input_mutex);
 }
 
-static void clamp_audio_output(struct audio_output *audio, size_t bytes,
-			       void *canvas)
+static void clamp_audio_output(struct audio_output *audio, size_t bytes, struct audio_mix_outputs *outputs)
 {
 	size_t float_size = bytes / sizeof(float);
 
 	for (size_t mix_idx = 0; mix_idx < MAX_AUDIO_MIXES; mix_idx++) {
-		struct audio_mix_buffer *output_mix =
-			get_audio_mix(audio, mix_idx, canvas);
+		struct audio_mix_buffer *output_mix = &outputs->buffers[mix_idx];
 		struct audio_mix *mix = &audio->mixes[mix_idx];
 
 		/* do not process mixing if a specific mix is inactive */
@@ -185,8 +161,7 @@ static void clamp_audio_output(struct audio_output *audio, size_t bytes,
 			float *mix_data = output_mix->data[plane];
 			float *mix_end = &mix_data[float_size];
 			/* Unclamped mix is copied directly. */
-			memcpy(mix->buffer_unclamped.data[plane], mix_data,
-			       bytes);
+			memcpy(mix->buffer_unclamped.data[plane], mix_data, bytes);
 
 			while (mix_data < mix_end) {
 				float val = *mix_data;
@@ -209,14 +184,12 @@ void prepare_mixes_outputs(size_t canvases, struct audio_output *audio)
 		struct obs_video_info *ovi = NULL;
 		if (obs->video.canvases.num == canvases)
 			ovi = obs->video.canvases.array[canvas_idx];
-		struct audio_mix_outputs *mixes =
-			audio->mixes_outputs.array + canvas_idx;
+		struct audio_mix_outputs *mixes = audio->mixes_outputs.array + canvas_idx;
 		mixes->canvas = ovi;
 	}
 }
 
-static void input_and_output(struct audio_output *audio, uint64_t audio_time,
-			     uint64_t prev_time)
+static void input_and_output(struct audio_output *audio, uint64_t audio_time, uint64_t prev_time)
 {
 	size_t bytes = AUDIO_OUTPUT_FRAMES * audio->block_size;
 	struct audio_data_mixes_outputs data;
@@ -245,40 +218,33 @@ static void input_and_output(struct audio_output *audio, uint64_t audio_time,
 	source_audio_mix_data_clean(&data);
 	/* clear mix buffers */
 	for (size_t mix_idx = 0; mix_idx < MAX_AUDIO_MIXES; mix_idx++) {
-		for (size_t canvas_idx = 0; canvas_idx < canvases;
-		     canvas_idx++) {
-			struct audio_mix_buffer *mix =
-				&audio->mixes_outputs.array[canvas_idx]
-					 .buffers[mix_idx];
+		for (size_t canvas_idx = 0; canvas_idx < canvases; canvas_idx++) {
+			struct audio_mix_buffer *mix = &audio->mixes_outputs.array[canvas_idx].buffers[mix_idx];
 
 			memset(mix->data, 0, sizeof(mix->data));
 
 			for (size_t i = 0; i < audio->planes; i++)
-				data.outputs.array[canvas_idx]
-					.output[mix_idx]
-					.data[i] = mix->data[i];
+				data.outputs.array[canvas_idx].output[mix_idx].data[i] = mix->data[i];
 		}
 	}
 
 	/* get new audio data */
-	success = audio->input_cb(audio->input_param, prev_time, audio_time,
-				  &new_ts, active_mixes, &data);
+	success = audio->input_cb(audio->input_param, prev_time, audio_time, &new_ts, active_mixes, &data);
 	source_audio_mix_data_release(&data);
 	if (!success)
 		return;
 
 	for (size_t canvas_idx = 0; canvas_idx < canvases; canvas_idx++) {
-		void *canvas = audio->mixes_outputs.array[canvas_idx].canvas;
-		obs_set_audio_rendering_canvas(canvas);
+		struct audio_mix_outputs *outputs = audio->mixes_outputs.array + canvas_idx;
+		obs_set_audio_rendering_canvas(outputs->canvas);
 
 		/* clamps audio data to -1.0..1.0 */
-		clamp_audio_output(audio, bytes, canvas);
+		clamp_audio_output(audio, bytes, outputs);
 
-		/* Pass the canvas explicitly because another audio output thread can
+		/* Pass the outputs explicitly because another audio output thread can
 		 * change the current audio rendering canvas concurrently. */
 		for (size_t i = 0; i < MAX_AUDIO_MIXES; i++)
-			do_audio_output(audio, i, new_ts, AUDIO_OUTPUT_FRAMES,
-					canvas);
+			do_audio_output(audio, i, new_ts, AUDIO_OUTPUT_FRAMES, outputs);
 	}
 }
 

--- a/libobs/media-io/audio-io.c
+++ b/libobs/media-io/audio-io.c
@@ -130,10 +130,10 @@ struct audio_mix_buffer *get_audio_mix(struct audio_output *audio,
 }
 
 static void do_audio_output(struct audio_output *audio, size_t mix_idx,
-			    uint64_t timestamp, uint32_t frames)
+			    uint64_t timestamp, uint32_t frames, void *canvas)
 {
 	struct audio_mix_buffer *output_mix =
-		get_audio_mix(audio, mix_idx, obs_get_audio_rendering_canvas());
+		get_audio_mix(audio, mix_idx, canvas);
 	struct audio_mix *mix = &audio->mixes[mix_idx];
 	struct audio_data data;
 
@@ -146,7 +146,7 @@ static void do_audio_output(struct audio_output *audio, size_t mix_idx,
 
 		struct obs_encoder *encoder = input->param;
 		if (encoder && encoder->video &&
-		    encoder->video->canvas_ovi != obs_get_audio_rendering_canvas()) {
+		    encoder->video->canvas_ovi != canvas) {
 			continue;
 		}
 		float(*buf)[AUDIO_OUTPUT_FRAMES] =
@@ -167,13 +167,14 @@ static void do_audio_output(struct audio_output *audio, size_t mix_idx,
 	pthread_mutex_unlock(&audio->input_mutex);
 }
 
-static void clamp_audio_output(struct audio_output *audio, size_t bytes)
+static void clamp_audio_output(struct audio_output *audio, size_t bytes,
+			       void *canvas)
 {
 	size_t float_size = bytes / sizeof(float);
 
 	for (size_t mix_idx = 0; mix_idx < MAX_AUDIO_MIXES; mix_idx++) {
-		struct audio_mix_buffer *output_mix = get_audio_mix(
-			audio, mix_idx, obs_get_audio_rendering_canvas());
+		struct audio_mix_buffer *output_mix =
+			get_audio_mix(audio, mix_idx, canvas);
 		struct audio_mix *mix = &audio->mixes[mix_idx];
 
 		/* do not process mixing if a specific mix is inactive */
@@ -267,15 +268,17 @@ static void input_and_output(struct audio_output *audio, uint64_t audio_time,
 		return;
 
 	for (size_t canvas_idx = 0; canvas_idx < canvases; canvas_idx++) {
-		obs_set_audio_rendering_canvas(
-			audio->mixes_outputs.array[canvas_idx].canvas);
+		void *canvas = audio->mixes_outputs.array[canvas_idx].canvas;
+		obs_set_audio_rendering_canvas(canvas);
 
 		/* clamps audio data to -1.0..1.0 */
-		clamp_audio_output(audio, bytes);
+		clamp_audio_output(audio, bytes, canvas);
 
-		/* output audio*/
+		/* Route with the loop-local identity: another audio_t thread may
+		 * update the legacy global rendering context concurrently. */
 		for (size_t i = 0; i < MAX_AUDIO_MIXES; i++)
-			do_audio_output(audio, i, new_ts, AUDIO_OUTPUT_FRAMES);
+			do_audio_output(audio, i, new_ts, AUDIO_OUTPUT_FRAMES,
+					canvas);
 	}
 }
 

--- a/libobs/obs-encoder.c
+++ b/libobs/obs-encoder.c
@@ -254,13 +254,12 @@ struct gpu_rescale_mix_key {
 	struct obs_view *view;
 	struct obs_video_info *canvas_ovi;
 	enum obs_video_rendering_mode rendering_mode;
-	bool preserve_frame_rate;
 };
 
 static bool video_mix_matches_key(const struct obs_core_video_mix *mix, const struct gpu_rescale_mix_key *key)
 {
 	return mix->view == key->view && mix->canvas_ovi == key->canvas_ovi &&
-	       mix->rendering_mode == key->rendering_mode && mix->preserve_frame_rate == key->preserve_frame_rate;
+	       mix->rendering_mode == key->rendering_mode;
 }
 
 static bool video_mix_matches_gpu_rescale(const struct obs_core_video_mix *mix, const struct gpu_rescale_mix_key *key,
@@ -318,7 +317,6 @@ static void maybe_set_up_gpu_rescale(struct obs_encoder *encoder)
 		.view = current_mix->view,
 		.canvas_ovi = current_mix->canvas_ovi,
 		.rendering_mode = current_mix->rendering_mode,
-		.preserve_frame_rate = current_mix->preserve_frame_rate,
 	};
 
 	const struct obs_video_info source_info = current_mix->ovi;
@@ -356,8 +354,7 @@ static void maybe_set_up_gpu_rescale(struct obs_encoder *encoder)
 	if (mix)
 		return;
 
-	mix = obs_create_video_mix_internal(&desired, key.canvas_ovi, OBS_CORE_VIDEO_MIX_KIND_ENCODER_ONLY,
-					    key.preserve_frame_rate);
+	mix = obs_create_video_mix_internal(&desired, key.canvas_ovi, OBS_CORE_VIDEO_MIX_KIND_ENCODER_ONLY);
 	if (!mix)
 		return;
 

--- a/libobs/obs-encoder.c
+++ b/libobs/obs-encoder.c
@@ -272,7 +272,7 @@ static void maybe_set_up_gpu_rescale(struct obs_encoder *encoder)
 		return;
 
 	/* Store original video_t so it can be restored if scaling is disabled. */
-	if (!current_mix->encoder_only_mix)
+	if (current_mix->kind != OBS_CORE_VIDEO_MIX_KIND_ENCODER_ONLY)
 		encoder->original_video = encoder->media;
 
 	pthread_mutex_lock(&obs->video.mixes_mutex);
@@ -329,7 +329,7 @@ static void maybe_set_up_gpu_rescale(struct obs_encoder *encoder)
 	if (!mix)
 		return;
 
-	mix->encoder_only_mix = true;
+	mix->kind = OBS_CORE_VIDEO_MIX_KIND_ENCODER_ONLY;
 	mix->encoder_refs = 1;
 	mix->canvas_ovi = current_mix->canvas_ovi;
 	mix->view = current_mix->view;
@@ -750,7 +750,7 @@ static void maybe_clear_encoder_core_video_mix(obs_encoder_t *encoder)
 		if (mix->video != encoder->media)
 			continue;
 
-		if (!mix->encoder_only_mix)
+		if (mix->kind != OBS_CORE_VIDEO_MIX_KIND_ENCODER_ONLY)
 			break;
 
 		video_t *original_video = encoder->original_video;
@@ -1341,7 +1341,7 @@ static void encoder_set_video_internal(obs_encoder_t *encoder, video_t *video,
 	}
 
 	encoder->video = mix;
-	if (!mix || !mix->encoder_only_mix)
+	if (!mix || mix->kind != OBS_CORE_VIDEO_MIX_KIND_ENCODER_ONLY)
 		encoder->original_video = NULL;
 
 	if (video) {

--- a/libobs/obs-encoder.c
+++ b/libobs/obs-encoder.c
@@ -285,6 +285,12 @@ static void maybe_set_up_gpu_rescale(struct obs_encoder *encoder)
 			continue;
 		if (current_mix->rendering_mode != current->rendering_mode)
 			continue;
+		if (current_mix->preserve_frame_rate !=
+		    current->preserve_frame_rate)
+			continue;
+		if (current_mix->ovi.fps_num != current->ovi.fps_num ||
+		    current_mix->ovi.fps_den != current->ovi.fps_den)
+			continue;
 
 		if (current->ovi.scale_type != encoder->gpu_scale_type)
 			continue;
@@ -318,7 +324,8 @@ static void maybe_set_up_gpu_rescale(struct obs_encoder *encoder)
 
 	ovi.gpu_conversion = true;
 
-	mix = obs_create_video_mix(&ovi);
+	mix = obs_create_video_mix_with_frame_rate(
+		&ovi, current_mix->preserve_frame_rate);
 	if (!mix)
 		return;
 
@@ -341,6 +348,12 @@ static void maybe_set_up_gpu_rescale(struct obs_encoder *encoder)
 		if (current->canvas_ovi != current_mix->canvas_ovi)
 			continue;
 		if (current->rendering_mode != current_mix->rendering_mode)
+			continue;
+		if (current->preserve_frame_rate !=
+		    current_mix->preserve_frame_rate)
+			continue;
+		if (current->ovi.fps_num != current_mix->ovi.fps_num ||
+		    current->ovi.fps_den != current_mix->ovi.fps_den)
 			continue;
 
 		if (current->ovi.scale_type != encoder->gpu_scale_type)

--- a/libobs/obs-encoder.c
+++ b/libobs/obs-encoder.c
@@ -25,9 +25,8 @@
 #define get_weak(encoder) ((obs_weak_encoder_t *)encoder->context.control)
 
 static void encoder_set_video(obs_encoder_t *encoder, video_t *video);
-static void encoder_set_video_internal(obs_encoder_t *encoder, video_t *video,
-				       struct obs_core_video_mix *mix);
-static struct obs_core_video_mix *get_mix_for_video_locked(video_t *video);
+static void encoder_set_video_internal(obs_encoder_t *encoder, video_t *video, struct obs_core_video_mix *mix);
+static void release_encoder_only_gpu_rescale_mix(obs_encoder_t *encoder);
 
 struct obs_encoder_info *find_encoder(const char *id)
 {
@@ -83,10 +82,10 @@ enum obs_module_load_state obs_encoder_load_state(const char *id)
 
 static bool init_encoder(struct obs_encoder *encoder, const char *name, obs_data_t *settings, obs_data_t *hotkey_data)
 {
-	blog(LOG_INFO, "init_encoder - begin '%s' (%s) (%p)", name,
-	     obs_encoder_get_id(encoder), encoder);
+	blog(LOG_INFO, "init_encoder - begin '%s' (%s) (%p)", name, obs_encoder_get_id(encoder), encoder);
 
 	pthread_mutex_init_value(&encoder->init_mutex);
+	pthread_mutex_init_value(&encoder->video_mix_removal_mutex);
 	pthread_mutex_init_value(&encoder->callbacks_mutex);
 	pthread_mutex_init_value(&encoder->outputs_mutex);
 	pthread_mutex_init_value(&encoder->pause.mutex);
@@ -95,6 +94,8 @@ static bool init_encoder(struct obs_encoder *encoder, const char *name, obs_data
 	if (!obs_context_data_init(&encoder->context, OBS_OBJ_TYPE_ENCODER, settings, name, NULL, hotkey_data, false))
 		return false;
 	if (pthread_mutex_init_recursive(&encoder->init_mutex) != 0)
+		return false;
+	if (pthread_mutex_init(&encoder->video_mix_removal_mutex, NULL) != 0)
 		return false;
 	if (pthread_mutex_init_recursive(&encoder->callbacks_mutex) != 0)
 		return false;
@@ -112,8 +113,7 @@ static bool init_encoder(struct obs_encoder *encoder, const char *name, obs_data
 		encoder->orig_info.get_defaults2(encoder->context.settings, encoder->orig_info.type_data);
 	}
 
-	blog(LOG_INFO, "init_encoder - end '%s' (%s) (%p)", name,
-	     obs_encoder_get_id(encoder), encoder);
+	blog(LOG_INFO, "init_encoder - end '%s' (%s) (%p)", name, obs_encoder_get_id(encoder), encoder);
 
 	return true;
 }
@@ -235,22 +235,68 @@ static inline bool gpu_encode_available(const struct obs_encoder *encoder)
 }
 
 /**
- * GPU based rescaling is currently implemented via core video mixes,
- * i.e. a core mix with matching width/height/format/colorspace/range
- * will be created if it doesn't exist already to generate encoder
- * input
+ * GPU-based rescaling uses encoder-only video mixes. Encoders reuse a mix only
+ * when its canvas identity, rendering mode, frame cadence, and render settings
+ * match the requested encoder input.
  */
+static bool video_info_matches_gpu_rescale(const struct obs_video_info *actual, const struct obs_video_info *desired)
+{
+	return actual->fps_num == desired->fps_num && actual->fps_den == desired->fps_den &&
+	       actual->fps_type == desired->fps_type && actual->base_width == desired->base_width &&
+	       actual->base_height == desired->base_height && actual->output_width == desired->output_width &&
+	       actual->output_height == desired->output_height && actual->output_format == desired->output_format &&
+	       actual->adapter == desired->adapter && actual->gpu_conversion == desired->gpu_conversion &&
+	       actual->colorspace == desired->colorspace && actual->range == desired->range &&
+	       actual->scale_type == desired->scale_type;
+}
+
+struct gpu_rescale_mix_key {
+	struct obs_view *view;
+	struct obs_video_info *canvas_ovi;
+	enum obs_video_rendering_mode rendering_mode;
+	bool preserve_frame_rate;
+};
+
+static bool video_mix_matches_key(const struct obs_core_video_mix *mix, const struct gpu_rescale_mix_key *key)
+{
+	return mix->view == key->view && mix->canvas_ovi == key->canvas_ovi &&
+	       mix->rendering_mode == key->rendering_mode && mix->preserve_frame_rate == key->preserve_frame_rate;
+}
+
+static bool video_mix_matches_gpu_rescale(const struct obs_core_video_mix *mix, const struct gpu_rescale_mix_key *key,
+					  const struct obs_video_info *desired)
+{
+	return video_mix_matches_key(mix, key) && video_info_matches_gpu_rescale(&mix->ovi, desired);
+}
+
+static struct obs_core_video_mix *find_encoder_only_gpu_rescale_mix_locked(const struct gpu_rescale_mix_key *key,
+									   const struct obs_video_info *desired)
+{
+	for (size_t i = 0; i < obs->video.mixes.num; i++) {
+		struct obs_core_video_mix *mix = obs->video.mixes.array[i];
+
+		if (mix->kind == OBS_CORE_VIDEO_MIX_KIND_ENCODER_ONLY &&
+		    video_mix_matches_gpu_rescale(mix, key, desired))
+			return mix;
+	}
+
+	return NULL;
+}
+
+static void acquire_encoder_only_gpu_rescale_mix(struct obs_encoder *encoder, struct obs_core_video_mix *mix,
+						 video_t *original_video)
+{
+	assert(mix->kind == OBS_CORE_VIDEO_MIX_KIND_ENCODER_ONLY);
+	assert(original_video != NULL);
+	encoder->original_video = original_video;
+	mix->encoder_refs++;
+	encoder_set_video_internal(encoder, mix->video, mix);
+}
+
 static void maybe_set_up_gpu_rescale(struct obs_encoder *encoder)
 {
 	blog(LOG_INFO, "maybe_set_up_gpu_rescale - %s", obs_encoder_get_name(encoder));
-	struct obs_core_video_mix *mix, *current_mix;
-	bool create_mix = true;
 	const struct video_output_info *info;
-	uint32_t width;
-	uint32_t height;
-	enum video_format format;
-	enum video_colorspace space;
-	enum video_range_type range;
 
 	if (!encoder->media)
 		return;
@@ -260,125 +306,83 @@ static void maybe_set_up_gpu_rescale(struct obs_encoder *encoder)
 	    encoder->preferred_space == VIDEO_CS_DEFAULT && encoder->preferred_range == VIDEO_RANGE_DEFAULT)
 		return;
 
-	info = video_output_get_info(encoder->media);
-	width = encoder->scaled_width ? encoder->scaled_width : info->width;
-	height = encoder->scaled_height ? encoder->scaled_height : info->height;
-	format = encoder->preferred_format != VIDEO_FORMAT_NONE ? encoder->preferred_format : info->format;
-	space = encoder->preferred_space != VIDEO_CS_DEFAULT ? encoder->preferred_space : info->colorspace;
-	range = encoder->preferred_range != VIDEO_RANGE_DEFAULT ? encoder->preferred_range : info->range;
-
-	current_mix = get_mix_for_video(encoder->media);
-	if (!current_mix)
-		return;
-
-	/* Store original video_t so it can be restored if scaling is disabled. */
-	if (current_mix->kind != OBS_CORE_VIDEO_MIX_KIND_ENCODER_ONLY)
-		encoder->original_video = encoder->media;
-
 	pthread_mutex_lock(&obs->video.mixes_mutex);
-	for (size_t i = 0; i < obs->video.mixes.num; i++) {
-		struct obs_core_video_mix *current = obs->video.mixes.array[i];
-		const struct video_output_info *voi = video_output_get_info(current->video);
-		if (current_mix->view != current->view)
-			continue;
-		if (current_mix->canvas_ovi != current->canvas_ovi)
-			continue;
-		if (current_mix->rendering_mode != current->rendering_mode)
-			continue;
-		if (current_mix->preserve_frame_rate !=
-		    current->preserve_frame_rate)
-			continue;
-		if (current_mix->ovi.fps_num != current->ovi.fps_num ||
-		    current_mix->ovi.fps_den != current->ovi.fps_den)
-			continue;
+	struct obs_core_video_mix *current_mix = get_mix_for_video_locked(encoder->media);
+	if (!current_mix) {
+		pthread_mutex_unlock(&obs->video.mixes_mutex);
+		return;
+	}
+	info = video_output_get_info(current_mix->video);
 
-		if (current->ovi.scale_type != encoder->gpu_scale_type)
-			continue;
+	const struct gpu_rescale_mix_key key = {
+		.view = current_mix->view,
+		.canvas_ovi = current_mix->canvas_ovi,
+		.rendering_mode = current_mix->rendering_mode,
+		.preserve_frame_rate = current_mix->preserve_frame_rate,
+	};
 
-		if (voi->width != width || voi->height != height)
-			continue;
+	const struct obs_video_info source_info = current_mix->ovi;
+	struct obs_video_info desired = source_info;
+	desired.output_width = encoder->scaled_width ? encoder->scaled_width : info->width;
+	desired.output_height = encoder->scaled_height ? encoder->scaled_height : info->height;
+	desired.output_format = encoder->preferred_format != VIDEO_FORMAT_NONE ? encoder->preferred_format
+									       : info->format;
+	desired.colorspace = encoder->preferred_space != VIDEO_CS_DEFAULT ? encoder->preferred_space : info->colorspace;
+	desired.range = encoder->preferred_range != VIDEO_RANGE_DEFAULT ? encoder->preferred_range : info->range;
+	desired.scale_type = encoder->gpu_scale_type;
+	desired.gpu_conversion = true;
 
-		if (voi->format != format || voi->colorspace != space || voi->range != range)
-			continue;
-
-		current->encoder_refs += 1;
-		encoder_set_video_internal(encoder, current->video, current);
-		create_mix = false;
-		break;
+	/* The scaling filter does not matter when the current mix already produces
+	 * the requested dimensions and pixel format. */
+	struct obs_video_info compatible_source = desired;
+	compatible_source.scale_type = current_mix->ovi.scale_type;
+	if (video_mix_matches_gpu_rescale(current_mix, &key, &compatible_source)) {
+		pthread_mutex_unlock(&obs->video.mixes_mutex);
+		return;
 	}
 
+	video_t *original_video = current_mix->kind == OBS_CORE_VIDEO_MIX_KIND_ENCODER_ONLY ? encoder->original_video
+											    : encoder->media;
+	if (!original_video) {
+		pthread_mutex_unlock(&obs->video.mixes_mutex);
+		return;
+	}
+
+	struct obs_core_video_mix *mix = find_encoder_only_gpu_rescale_mix_locked(&key, &desired);
+	if (mix)
+		acquire_encoder_only_gpu_rescale_mix(encoder, mix, original_video);
 	pthread_mutex_unlock(&obs->video.mixes_mutex);
 
-	if (!create_mix)
+	if (mix)
 		return;
 
-	struct obs_video_info ovi = current_mix->ovi;
-
-	ovi.output_format = format;
-	ovi.colorspace = space;
-	ovi.range = range;
-
-	ovi.output_height = height;
-	ovi.output_width = width;
-	ovi.scale_type = encoder->gpu_scale_type;
-
-	ovi.gpu_conversion = true;
-
-	mix = obs_create_video_mix_with_frame_rate(
-		&ovi, current_mix->preserve_frame_rate);
+	mix = obs_create_video_mix_internal(&desired, key.canvas_ovi, OBS_CORE_VIDEO_MIX_KIND_ENCODER_ONLY,
+					    key.preserve_frame_rate);
 	if (!mix)
 		return;
 
-	mix->kind = OBS_CORE_VIDEO_MIX_KIND_ENCODER_ONLY;
-	mix->encoder_refs = 1;
-	mix->canvas_ovi = current_mix->canvas_ovi;
-	mix->view = current_mix->view;
-	mix->rendering_mode = current_mix->rendering_mode;
+	mix->view = key.view;
+	mix->rendering_mode = key.rendering_mode;
 
 	struct obs_core_video_mix *to_free = NULL;
 
 	pthread_mutex_lock(&obs->video.mixes_mutex);
 
-	// double check that nobody else added a matching mix while we've created our mix
-	for (size_t i = 0; i < obs->video.mixes.num; i++) {
-		struct obs_core_video_mix *current = obs->video.mixes.array[i];
-		const struct video_output_info *voi = video_output_get_info(current->video);
-		if (current->view != current_mix->view)
-			continue;
-		if (current->canvas_ovi != current_mix->canvas_ovi)
-			continue;
-		if (current->rendering_mode != current_mix->rendering_mode)
-			continue;
-		if (current->preserve_frame_rate !=
-		    current_mix->preserve_frame_rate)
-			continue;
-		if (current->ovi.fps_num != current_mix->ovi.fps_num ||
-		    current->ovi.fps_den != current_mix->ovi.fps_den)
-			continue;
-
-		if (current->ovi.scale_type != encoder->gpu_scale_type)
-			continue;
-
-		if (voi->width != width || voi->height != height)
-			continue;
-
-		if (voi->format != format || voi->colorspace != space || voi->range != range)
-			continue;
-
-		current->encoder_refs += 1;
-		encoder_set_video_internal(encoder, current->video, current);
-		create_mix = false;
-		break;
-	}
-
-	if (!create_mix) {
+	/* Another encoder may have published the same mix while this one was
+	 * being created, so repeat the lookup before publishing. */
+	struct obs_core_video_mix *current_source = get_mix_for_video_locked(encoder->media);
+	struct obs_core_video_mix *published = find_encoder_only_gpu_rescale_mix_locked(&key, &desired);
+	if (!current_source || !video_mix_matches_gpu_rescale(current_source, &key, &source_info)) {
+		to_free = mix;
+	} else if (published) {
+		acquire_encoder_only_gpu_rescale_mix(encoder, published, original_video);
 		// mix was never published into obs->video.mixes; defer the free until
 		// after the unlock to avoid the same AB-BA with the graphics mutex
-		// documented on maybe_clear_encoder_core_video_mix.
+		// documented on release_encoder_only_gpu_rescale_mix.
 		to_free = mix;
 	} else {
 		da_push_back(obs->video.mixes, &mix);
-		encoder_set_video_internal(encoder, mix->video, mix);
+		acquire_encoder_only_gpu_rescale_mix(encoder, mix, original_video);
 	}
 
 	pthread_mutex_unlock(&obs->video.mixes_mutex);
@@ -389,8 +393,7 @@ static void maybe_set_up_gpu_rescale(struct obs_encoder *encoder)
 
 static void add_connection(struct obs_encoder *encoder)
 {
-	blog(LOG_INFO, "add_connection '%s' (%s) (%p)",
-	     obs_encoder_get_name(encoder), obs_encoder_get_id(encoder),
+	blog(LOG_INFO, "add_connection '%s' (%s) (%p)", obs_encoder_get_name(encoder), obs_encoder_get_id(encoder),
 	     encoder);
 	if (encoder->info.type == OBS_ENCODER_AUDIO) {
 		struct audio_convert_info audio_info = {0};
@@ -421,11 +424,13 @@ static void add_connection(struct obs_encoder *encoder)
 }
 
 void obs_encoder_group_actually_destroy(obs_encoder_group_t *group);
-static void remove_connection(struct obs_encoder *encoder, bool shutdown)
+static struct obs_encoder_group *remove_connection(struct obs_encoder *encoder, bool shutdown,
+						    bool claim_group_destruction)
 {
-	blog(LOG_INFO, "remove_connection - shutdown: %d '%s' (%s) (%p)",
-	     shutdown, obs_encoder_get_name(encoder),
+	assert(!claim_group_destruction || !shutdown);
+	blog(LOG_INFO, "remove_connection - shutdown: %d '%s' (%s) (%p)", shutdown, obs_encoder_get_name(encoder),
 	     obs_encoder_get_id(encoder), encoder);
+	struct obs_encoder_group *group_to_destroy = NULL;
 
 	if (encoder->info.type == OBS_ENCODER_AUDIO) {
 		audio_output_disconnect(encoder->media, encoder->mixer_idx, receive_audio, encoder);
@@ -441,7 +446,11 @@ static void remove_connection(struct obs_encoder *encoder, bool shutdown)
 		pthread_mutex_lock(&encoder->encoder_group->mutex);
 		if (--encoder->encoder_group->num_encoders_started == 0)
 			encoder->encoder_group->start_timestamp = 0;
-		pthread_mutex_unlock(&encoder->encoder_group->mutex);
+		if (claim_group_destruction && encoder->encoder_group->destroy_on_stop &&
+		    encoder->encoder_group->num_encoders_started == 0)
+			group_to_destroy = encoder->encoder_group;
+		else
+			pthread_mutex_unlock(&encoder->encoder_group->mutex);
 	}
 
 	/* obs_encoder_shutdown locks init_mutex, so don't call it on encode
@@ -454,6 +463,7 @@ static void remove_connection(struct obs_encoder *encoder, bool shutdown)
 	encoder->initialized = false;
 
 	set_encoder_active(encoder, false);
+	return group_to_destroy;
 }
 
 static inline void free_audio_buffers(struct obs_encoder *encoder)
@@ -465,12 +475,18 @@ static inline void free_audio_buffers(struct obs_encoder *encoder)
 	}
 }
 
+static void clear_paired_encoders(struct obs_encoder *encoder)
+{
+	for (size_t i = 0; i < encoder->paired_encoders.num; i++)
+		obs_weak_encoder_release(encoder->paired_encoders.array[i]);
+	da_free(encoder->paired_encoders);
+}
+
 void obs_encoder_destroy(obs_encoder_t *encoder)
 {
 	if (encoder) {
-		blog(LOG_INFO, "obs_encoder_actually_destroy '%s' (%s) (%p)",
-		     obs_encoder_get_name(encoder), obs_encoder_get_id(encoder),
-		     encoder);
+		blog(LOG_INFO, "obs_encoder_actually_destroy '%s' (%s) (%p)", obs_encoder_get_name(encoder),
+		     obs_encoder_get_id(encoder), encoder);
 		pthread_mutex_lock(&encoder->outputs_mutex);
 		for (size_t i = 0; i < encoder->outputs.num; i++) {
 			struct obs_output *output = encoder->outputs.array[i];
@@ -481,8 +497,7 @@ void obs_encoder_destroy(obs_encoder_t *encoder)
 		da_free(encoder->outputs);
 		pthread_mutex_unlock(&encoder->outputs_mutex);
 
-		blog(LOG_DEBUG, "encoder '%s' destroyed (%p)",
-		     encoder->context.name, encoder);
+		blog(LOG_DEBUG, "encoder '%s' destroyed (%p)", encoder->context.name, encoder);
 
 		obs_encoder_set_group(encoder, NULL);
 
@@ -490,10 +505,13 @@ void obs_encoder_destroy(obs_encoder_t *encoder)
 
 		if (encoder->context.data)
 			encoder->info.destroy(encoder->context.data);
+		release_encoder_only_gpu_rescale_mix(encoder);
+		clear_paired_encoders(encoder);
 		da_free(encoder->callbacks);
 		da_free(encoder->roi);
 		da_free(encoder->encoder_packet_times);
 		pthread_mutex_destroy(&encoder->init_mutex);
+		pthread_mutex_destroy(&encoder->video_mix_removal_mutex);
 		pthread_mutex_destroy(&encoder->callbacks_mutex);
 		pthread_mutex_destroy(&encoder->outputs_mutex);
 		pthread_mutex_destroy(&encoder->pause.mutex);
@@ -663,6 +681,12 @@ static THREAD_LOCAL bool can_reroute = false;
 static bool obs_encoder_initialize_internal(obs_encoder_t *encoder)
 {
 	blog(LOG_INFO, "obs_encoder_initialize_internal - %s", obs_encoder_get_name(encoder));
+	if (os_atomic_load_bool(&encoder->video_mix_removal_pending)) {
+		blog(LOG_WARNING, "obs_encoder_initialize_internal: encoder '%s' is stopping for video mix removal",
+		     encoder->context.name);
+		return false;
+	}
+
 	if (!encoder->media) {
 		blog(LOG_ERROR, "obs_encoder_initialize_internal: encoder '%s' has no media set",
 		     encoder->context.name);
@@ -684,8 +708,10 @@ static bool obs_encoder_initialize_internal(obs_encoder_t *encoder)
 		encoder->context.data = encoder->orig_info.create(encoder->context.settings, encoder);
 		can_reroute = false;
 	}
-	if (!encoder->context.data)
+	if (!encoder->context.data) {
+		release_encoder_only_gpu_rescale_mix(encoder);
 		return false;
+	}
 
 	if (encoder->orig_info.type == OBS_ENCODER_AUDIO)
 		intitialize_audio_encoder(encoder);
@@ -730,8 +756,9 @@ bool obs_encoder_initialize(obs_encoder_t *encoder)
 }
 
 /**
- * free video mix if it's an encoder only video mix
- * see `maybe_set_up_gpu_rescale`
+ * Releases the encoder-only GPU rescale mix acquired by
+ * maybe_set_up_gpu_rescale(). original_video is both the output restored after
+ * release and the ownership marker for the mix's encoder_refs entry.
  *
  * obs_free_video_mix takes the graphics mutex (via gs_enter_context in
  * obs_free_render_textures), and the graphics thread can be holding the
@@ -740,22 +767,26 @@ bool obs_encoder_initialize(obs_encoder_t *encoder)
  * the mix to free under the lock and free after release, matching the
  * pattern used by obs_free_video in obs.c.
  */
-static void maybe_clear_encoder_core_video_mix(obs_encoder_t *encoder)
+static void release_encoder_only_gpu_rescale_mix(obs_encoder_t *encoder)
 {
+	if (!obs || !encoder || !encoder->video || !encoder->original_video)
+		return;
+
 	struct obs_core_video_mix *to_free = NULL;
 
 	pthread_mutex_lock(&obs->video.mixes_mutex);
 	for (size_t i = 0; i < obs->video.mixes.num; i++) {
 		struct obs_core_video_mix *mix = obs->video.mixes.array[i];
-		if (mix->video != encoder->media)
+		if (mix != encoder->video)
 			continue;
 
 		if (mix->kind != OBS_CORE_VIDEO_MIX_KIND_ENCODER_ONLY)
 			break;
 
 		video_t *original_video = encoder->original_video;
-		encoder_set_video_internal(encoder, original_video,
-					   get_mix_for_video_locked(original_video));
+		struct obs_core_video_mix *original_mix = get_mix_for_video_locked(original_video);
+		encoder_set_video_internal(encoder, original_mix ? original_video : NULL, original_mix);
+		assert(mix->encoder_refs > 0);
 		mix->encoder_refs -= 1;
 		if (mix->encoder_refs == 0) {
 			da_erase(obs->video.mixes, i);
@@ -769,61 +800,122 @@ static void maybe_clear_encoder_core_video_mix(obs_encoder_t *encoder)
 		obs_free_video_mix(to_free);
 }
 
+/* Stops every output using the encoder without holding init_mutex across
+ * obs_output_force_stop(), which may join a reconnect thread that needs the
+ * same mutex. The caller holds init_mutex on entry and again on return. */
+static void force_stop_encoder_for_video_mix_removal(obs_encoder_t *encoder)
+{
+	DARRAY(obs_output_t *) outputs;
+	da_init(outputs);
+
+	assert(os_atomic_load_bool(&encoder->video_mix_removal_pending));
+	pthread_mutex_unlock(&encoder->init_mutex);
+
+	pthread_mutex_lock(&encoder->outputs_mutex);
+	for (size_t i = 0; i < encoder->outputs.num; i++) {
+		obs_output_t *output = obs_output_get_ref(encoder->outputs.array[i]);
+		if (output)
+			da_push_back(outputs, &output);
+	}
+	pthread_mutex_unlock(&encoder->outputs_mutex);
+
+	for (size_t i = 0; i < outputs.num; i++) {
+		obs_output_t *output = outputs.array[i];
+		obs_output_force_stop(output);
+
+		if (output->context.data && output->info.encoded_packet) {
+			pthread_mutex_lock(&output->interleaved_mutex);
+			output->info.encoded_packet(output->context.data, NULL);
+			pthread_mutex_unlock(&output->interleaved_mutex);
+		}
+		obs_output_release(output);
+	}
+	da_free(outputs);
+
+	pthread_mutex_lock(&encoder->init_mutex);
+	pthread_mutex_lock(&encoder->callbacks_mutex);
+	da_free(encoder->callbacks);
+	pthread_mutex_unlock(&encoder->callbacks_mutex);
+
+	/* A normal output stop may already have removed the connection while
+	 * init_mutex was unlocked. Complete it only if that did not happen. */
+	bool removed_connection = encoder_active(encoder);
+	struct obs_encoder_group *group_to_destroy = NULL;
+	if (removed_connection)
+		group_to_destroy = remove_connection(encoder, false, true);
+
+	if (group_to_destroy) {
+		pthread_mutex_unlock(&encoder->init_mutex);
+		obs_encoder_group_actually_destroy(group_to_destroy);
+		pthread_mutex_lock(&encoder->init_mutex);
+	}
+}
+
+static bool encoder_references_video_mix(const obs_encoder_t *encoder, const struct obs_core_video_mix *mix,
+					 video_t *video)
+{
+	if (encoder->video == mix)
+		return true;
+	if (encoder->info.type != OBS_ENCODER_VIDEO || !video)
+		return false;
+	return encoder->media == video || encoder->original_video == video;
+}
+
 void obs_encoder_release_video_mix_references(struct obs_core_video_mix *mix)
 {
 	if (!obs || !mix)
 		return;
 
+	pthread_mutex_lock(&obs->video.mix_cleanup_mutex);
 	video_t *freed_video = mix->video;
 
-	DARRAY(obs_encoder_t *) elimenated;
-	da_init(elimenated);
+	DARRAY(obs_encoder_t *) encoders;
+	da_init(encoders);
 
+	/* Encoder media pointers are protected by init_mutex. Snapshot strong
+	 * references here, then determine which encoders are affected below. */
 	pthread_mutex_lock(&obs->data.encoders_mutex);
 	obs_encoder_t *encoder = obs->data.first_encoder;
 	while (encoder) {
 		obs_encoder_t *next = (obs_encoder_t *)encoder->context.next;
-		if (encoder->info.type == OBS_ENCODER_VIDEO &&
-		    ((encoder->video == mix) || (freed_video && encoder->media == freed_video))) {
-			obs_encoder_t *ref = obs_encoder_get_ref(encoder);
-			if (ref)
-				da_push_back(elimenated, &ref);
-		}
+		obs_encoder_t *ref = obs_encoder_get_ref(encoder);
+		if (ref)
+			da_push_back(encoders, &ref);
 		encoder = next;
 	}
 	pthread_mutex_unlock(&obs->data.encoders_mutex);
 
-	for (size_t i = 0; i < elimenated.num; i++) {
-		obs_encoder_t *enc = elimenated.array[i];
+	for (size_t i = 0; i < encoders.num; i++) {
+		obs_encoder_t *enc = encoders.array[i];
 
+		/* Source and encoder-only mixes can be removed concurrently. Keep
+		 * ownership while init_mutex is dropped to stop outputs. */
+		pthread_mutex_lock(&enc->video_mix_removal_mutex);
 		pthread_mutex_lock(&enc->init_mutex);
+		if (!encoder_references_video_mix(enc, mix, freed_video))
+			goto unlock_encoder;
+
+		assert(!os_atomic_load_bool(&enc->video_mix_removal_pending));
+		os_atomic_set_bool(&enc->video_mix_removal_pending, true);
+
+		if (enc->info.type == OBS_ENCODER_AUDIO) {
+			if (encoder_active(enc)) {
+				blog(LOG_ERROR,
+				     "obs_encoder_release_video_mix_references: active audio encoder '%s' references a freed video mix; forcing output stop (mix removal requires stopped encoders)",
+				     obs_encoder_get_name(enc));
+				force_stop_encoder_for_video_mix_removal(enc);
+			}
+			if (enc->video == mix)
+				enc->video = NULL;
+			clear_paired_encoders(enc);
+			goto finish_removal;
+		}
 
 		if (encoder_active(enc)) {
-			/* Unexpected: active encoder still references a freed mix. */
-			bool gpu = (enc->info.caps & OBS_ENCODER_CAP_PASS_TEXTURE) != 0 &&
-				   (mix->using_p010_tex || mix->using_nv12_tex);
-
-			if (gpu) {
-				/* Keep codec state; just clear media pointers. */
-				blog(LOG_ERROR,
-				     "obs_encoder_release_video_mix_references: active GPU encoder '%s' references a freed video mix; leaving codec state (reset path should have been blocked)",
-				     obs_encoder_get_name(enc));
-				if (enc->video == mix)
-					enc->video = NULL;
-				enc->media = NULL;
-				pthread_mutex_unlock(&enc->init_mutex);
-				obs_encoder_release(enc);
-				continue;
-			}
-
-			/* Raw path: disconnect callback and mark inactive. */
 			blog(LOG_ERROR,
-			     "obs_encoder_release_video_mix_references: active raw encoder '%s' references a freed video mix; forcing disconnect (reset path should have been blocked)",
+			     "obs_encoder_release_video_mix_references: active video encoder '%s' references a freed video mix; forcing output stop (mix removal requires stopped encoders)",
 			     obs_encoder_get_name(enc));
-
-			if (freed_video)
-				video_output_disconnect2(freed_video, receive_video, enc);
-			set_encoder_active(enc, false);
+			force_stop_encoder_for_video_mix_removal(enc);
 		}
 
 		if (enc->context.data) {
@@ -834,22 +926,27 @@ void obs_encoder_release_video_mix_references(struct obs_core_video_mix *mix)
 			enc->start_ts = 0;
 			enc->frame_rate_divisor_counter = 0;
 		}
+		clear_paired_encoders(enc);
 		enc->initialized = false;
-		if (enc->video == mix)
-			enc->video = NULL;
-		encoder_set_video(enc, NULL);
-		pthread_mutex_unlock(&enc->init_mutex);
+		release_encoder_only_gpu_rescale_mix(enc);
+		encoder_set_video_internal(enc, NULL, NULL);
 
+finish_removal:
+		os_atomic_set_bool(&enc->video_mix_removal_pending, false);
+
+unlock_encoder:
+		pthread_mutex_unlock(&enc->init_mutex);
+		pthread_mutex_unlock(&enc->video_mix_removal_mutex);
 		obs_encoder_release(enc);
 	}
-	da_free(elimenated);
+	da_free(encoders);
+	pthread_mutex_unlock(&obs->video.mix_cleanup_mutex);
 }
 
 void obs_encoder_shutdown(obs_encoder_t *encoder)
 {
-	blog(LOG_INFO, "obs_encoder_shutdown '%s' (%s) (%p)",
-	     obs_encoder_get_name(encoder), obs_encoder_get_id(encoder),
-	     encoder);
+	blog(LOG_INFO, "obs_encoder_shutdown '%s' (%s) (%p)", obs_encoder_get_name(encoder),
+	     obs_encoder_get_id(encoder), encoder);
 
 	pthread_mutex_lock(&encoder->init_mutex);
 	if (encoder->context.data) {
@@ -859,13 +956,9 @@ void obs_encoder_shutdown(obs_encoder_t *encoder)
 		encoder->offset_usec = 0;
 		encoder->start_ts = 0;
 		encoder->frame_rate_divisor_counter = 0;
-		maybe_clear_encoder_core_video_mix(encoder);
-
-		for (size_t i = 0; i < encoder->paired_encoders.num; i++) {
-			obs_weak_encoder_release(encoder->paired_encoders.array[i]);
-		}
-		da_free(encoder->paired_encoders);
 	}
+	clear_paired_encoders(encoder);
+	release_encoder_only_gpu_rescale_mix(encoder);
 	obs_encoder_set_last_error(encoder, NULL);
 	pthread_mutex_unlock(&encoder->init_mutex);
 }
@@ -892,16 +985,18 @@ void pause_reset(struct pause_data *pause)
 	pthread_mutex_unlock(&pause->mutex);
 }
 
-static inline void obs_encoder_start_internal(obs_encoder_t *encoder, encoded_callback_t new_packet, void *param)
+static inline bool obs_encoder_start_internal(obs_encoder_t *encoder, encoded_callback_t new_packet, void *param)
 {
-	blog(LOG_INFO, "obs_encoder_start_internal '%s' (%s) (%p)",
-	     obs_encoder_get_name(encoder), obs_encoder_get_id(encoder),
-	     encoder);
+	blog(LOG_INFO, "obs_encoder_start_internal '%s' (%s) (%p)", obs_encoder_get_name(encoder),
+	     obs_encoder_get_id(encoder), encoder);
 	struct encoder_callback cb = {false, new_packet, param};
 	bool first = false;
 
+	if (os_atomic_load_bool(&encoder->video_mix_removal_pending))
+		return false;
+
 	if (!encoder->context.data || !encoder->media)
-		return;
+		return false;
 
 	pthread_mutex_lock(&encoder->callbacks_mutex);
 
@@ -920,25 +1015,32 @@ static inline void obs_encoder_start_internal(obs_encoder_t *encoder, encoded_ca
 		encoder->cur_pts = 0;
 		add_connection(encoder);
 	}
+
+	return true;
+}
+
+bool obs_encoder_start_if_ready(obs_encoder_t *encoder, encoded_callback_t new_packet, void *param)
+{
+	if (!obs_encoder_valid(encoder, "obs_encoder_start"))
+		return false;
+	if (!obs_ptr_valid(new_packet, "obs_encoder_start"))
+		return false;
+
+	pthread_mutex_lock(&encoder->init_mutex);
+	bool success = obs_encoder_start_internal(encoder, new_packet, param);
+	pthread_mutex_unlock(&encoder->init_mutex);
+	return success;
 }
 
 void obs_encoder_start(obs_encoder_t *encoder, encoded_callback_t new_packet, void *param)
 {
-	if (!obs_encoder_valid(encoder, "obs_encoder_start"))
-		return;
-	if (!obs_ptr_valid(new_packet, "obs_encoder_start"))
-		return;
-
-	pthread_mutex_lock(&encoder->init_mutex);
-	obs_encoder_start_internal(encoder, new_packet, param);
-	pthread_mutex_unlock(&encoder->init_mutex);
+	obs_encoder_start_if_ready(encoder, new_packet, param);
 }
 
 void obs_encoder_stop(obs_encoder_t *encoder, encoded_callback_t new_packet, void *param)
 {
-	blog(LOG_INFO, "obs_encoder_stop_internal '%s' (%s) (%p)",
-	     obs_encoder_get_name(encoder), obs_encoder_get_id(encoder),
-	     encoder);
+	blog(LOG_INFO, "obs_encoder_stop_internal '%s' (%s) (%p)", obs_encoder_get_name(encoder),
+	     obs_encoder_get_id(encoder), encoder);
 	bool last = false;
 	size_t idx;
 
@@ -961,7 +1063,7 @@ void obs_encoder_stop(obs_encoder_t *encoder, encoded_callback_t new_packet, voi
 	encoder->encoder_packet_times.num = 0;
 
 	if (last) {
-		remove_connection(encoder, true);
+		remove_connection(encoder, true, false);
 		pthread_mutex_unlock(&encoder->init_mutex);
 
 		struct obs_encoder_group *group = encoder->encoder_group;
@@ -1277,15 +1379,18 @@ static bool encoder_can_set_video(obs_encoder_t *encoder, const char *func)
 	if (!obs_encoder_valid(encoder, func))
 		return false;
 	if (encoder->info.type != OBS_ENCODER_VIDEO) {
-		blog(LOG_WARNING,
-		     "%s: encoder '%s' is not a video encoder",
-		     func, obs_encoder_get_name(encoder));
+		blog(LOG_WARNING, "%s: encoder '%s' is not a video encoder", func, obs_encoder_get_name(encoder));
 		return false;
 	}
 	if (encoder_active(encoder)) {
 		blog(LOG_WARNING,
 		     "encoder '%s': Cannot apply a new video_t "
 		     "object while the encoder is active",
+		     obs_encoder_get_name(encoder));
+		return false;
+	}
+	if (os_atomic_load_bool(&encoder->video_mix_removal_pending)) {
+		blog(LOG_WARNING, "encoder '%s': Cannot change its video while stopping for video mix removal",
 		     obs_encoder_get_name(encoder));
 		return false;
 	}
@@ -1302,25 +1407,13 @@ static bool encoder_can_set_video(obs_encoder_t *encoder, const char *func)
 
 void obs_encoder_set_video(obs_encoder_t *encoder, video_t *video)
 {
-	if (!encoder_can_set_video(encoder, "obs_encoder_set_video"))
+	if (!obs_encoder_valid(encoder, "obs_encoder_set_video"))
 		return;
 
-	encoder_set_video(encoder, video);
-}
-
-static struct obs_core_video_mix *get_mix_for_video_locked(video_t *video)
-{
-	if (!video || !obs)
-		return NULL;
-
-	for (size_t i = 0, num = obs->video.mixes.num; i < num; i++) {
-		struct obs_core_video_mix *mix = obs->video.mixes.array[i];
-
-		if (mix && mix->video == video)
-			return mix;
-	}
-
-	return NULL;
+	pthread_mutex_lock(&encoder->init_mutex);
+	if (encoder_can_set_video(encoder, "obs_encoder_set_video"))
+		encoder_set_video(encoder, video);
+	pthread_mutex_unlock(&encoder->init_mutex);
 }
 
 static void encoder_set_video(obs_encoder_t *encoder, video_t *video)
@@ -1330,8 +1423,7 @@ static void encoder_set_video(obs_encoder_t *encoder, video_t *video)
 	pthread_mutex_unlock(&obs->video.mixes_mutex);
 }
 
-static void encoder_set_video_internal(obs_encoder_t *encoder, video_t *video,
-				       struct obs_core_video_mix *mix)
+static void encoder_set_video_internal(obs_encoder_t *encoder, video_t *video, struct obs_core_video_mix *mix)
 {
 	const struct video_output_info *voi;
 
@@ -1365,19 +1457,26 @@ void obs_encoder_set_audio(obs_encoder_t *encoder, audio_t *audio)
 {
 	if (!obs_encoder_valid(encoder, "obs_encoder_set_audio"))
 		return;
+
+	pthread_mutex_lock(&encoder->init_mutex);
 	if (encoder->info.type != OBS_ENCODER_AUDIO) {
 		blog(LOG_WARNING,
 		     "obs_encoder_set_audio: "
 		     "encoder '%s' is not an audio encoder",
 		     obs_encoder_get_name(encoder));
-		return;
+		goto unlock;
 	}
 	if (encoder_active(encoder)) {
 		blog(LOG_WARNING,
 		     "encoder '%s': Cannot apply a new audio_t "
 		     "object while the encoder is active",
 		     obs_encoder_get_name(encoder));
-		return;
+		goto unlock;
+	}
+	if (os_atomic_load_bool(&encoder->video_mix_removal_pending)) {
+		blog(LOG_WARNING, "encoder '%s': Cannot change its audio while stopping for video mix removal",
+		     obs_encoder_get_name(encoder));
+		goto unlock;
 	}
 
 	if (audio) {
@@ -1389,6 +1488,9 @@ void obs_encoder_set_audio(obs_encoder_t *encoder, audio_t *audio)
 		encoder->timebase_num = 0;
 		encoder->timebase_den = 0;
 	}
+
+unlock:
+	pthread_mutex_unlock(&encoder->init_mutex);
 }
 
 video_t *obs_encoder_video(const obs_encoder_t *encoder)
@@ -1512,7 +1614,7 @@ void full_stop(struct obs_encoder *encoder)
 		da_free(encoder->callbacks);
 		pthread_mutex_unlock(&encoder->callbacks_mutex);
 
-		remove_connection(encoder, false);
+		remove_connection(encoder, false, false);
 	}
 }
 
@@ -1943,14 +2045,17 @@ end:
 	profile_end(receive_audio_name);
 }
 
-void obs_encoder_add_output(struct obs_encoder *encoder, struct obs_output *output)
+bool obs_encoder_add_output(struct obs_encoder *encoder, struct obs_output *output)
 {
 	if (!encoder || !output)
-		return;
+		return false;
 
 	pthread_mutex_lock(&encoder->outputs_mutex);
-	da_push_back(encoder->outputs, &output);
+	bool added = !os_atomic_load_bool(&encoder->video_mix_removal_pending);
+	if (added)
+		da_push_back(encoder->outputs, &output);
 	pthread_mutex_unlock(&encoder->outputs_mutex);
+	return added;
 }
 
 void obs_encoder_remove_output(struct obs_encoder *encoder, struct obs_output *output)
@@ -2171,49 +2276,48 @@ void obs_encoder_set_last_error(obs_encoder_t *encoder, const char *message)
 		encoder->last_error_message = NULL;
 }
 
-void obs_encoder_set_video_mix(obs_encoder_t *encoder, struct obs_core_video_mix *video)
+void obs_encoder_set_video_mix(obs_encoder_t *encoder, struct obs_core_video_mix *mix)
 {
 	if (!obs_encoder_valid(encoder, "obs_encoder_set_video_mix"))
 		return;
 
-	if (!video) {
+	if (!mix) {
 		blog(LOG_WARNING, "obs_encoder_set_video_mix: NULL mix for encoder '%s'",
 		     obs_encoder_get_name(encoder));
 		return;
 	}
 
+	pthread_mutex_lock(&encoder->init_mutex);
 	const bool video_encoder = encoder->info.type == OBS_ENCODER_VIDEO;
 	if (video_encoder) {
+		if (!encoder_can_set_video(encoder, "obs_encoder_set_video_mix"))
+			goto unlock;
+	} else {
 		if (encoder_active(encoder)) {
-			blog(LOG_WARNING,
-			     "encoder '%s': Cannot apply a new video_t "
-			     "object while the encoder is active",
+			blog(LOG_WARNING, "encoder '%s': Cannot change its video mix while the encoder is active",
 			     obs_encoder_get_name(encoder));
-			return;
+			goto unlock;
 		}
-		if (encoder->initialized) {
+		if (os_atomic_load_bool(&encoder->video_mix_removal_pending)) {
 			blog(LOG_WARNING,
-			     "encoder '%s': Cannot apply a new video_t object "
-			     "after the encoder has been initialized",
+			     "encoder '%s': Cannot change its video mix while stopping for video mix removal",
 			     obs_encoder_get_name(encoder));
-			return;
+			goto unlock;
 		}
 	}
 
-	/* Validate and publish under mixes_mutex in a single critical section.
-	 * Free paths (obs_canvas_clear_mix / obs_free_video / output_frames) remove
-	 * the mix under mixes_mutex before calling obs_encoder_release_video_mix_references,
-	 * so either the removal is ordered before our lock (we see the mix gone and bail)
-	 * or after our unlock (the subsequent encoder walk sees encoder->media via the
-	 * release-acquire chain through mixes_mutex and clears it). */
+	/* Validate and publish under mixes_mutex in one critical section. Removal
+	 * paths detach the mix under the same mutex before walking encoders, so they
+	 * either win this race or subsequently clear this encoder binding under
+	 * init_mutex. */
 	bool bound = false;
 	pthread_mutex_lock(&obs->video.mixes_mutex);
 	for (size_t i = 0, num = obs->video.mixes.num; i < num; i++) {
-		if (obs->video.mixes.array[i] == video) {
+		if (obs->video.mixes.array[i] == mix) {
 			if (video_encoder)
-				encoder_set_video_internal(encoder, video->video, video);
+				encoder_set_video_internal(encoder, mix->video, mix);
 			else
-				encoder->video = video;
+				encoder->video = mix;
 			bound = true;
 			break;
 		}
@@ -2223,6 +2327,9 @@ void obs_encoder_set_video_mix(obs_encoder_t *encoder, struct obs_core_video_mix
 	if (!bound)
 		blog(LOG_WARNING, "obs_encoder_set_video_mix: stale mix for encoder '%s'",
 		     obs_encoder_get_name(encoder));
+
+unlock:
+	pthread_mutex_unlock(&encoder->init_mutex);
 }
 
 uint64_t obs_encoder_get_pause_offset(const obs_encoder_t *encoder)
@@ -2319,6 +2426,11 @@ bool obs_encoder_set_group(obs_encoder_t *encoder, obs_encoder_group_t *group)
 
 	if (obs_encoder_active(encoder)) {
 		blog(LOG_ERROR, "obs_encoder_set_group: encoder '%s' is already active", obs_encoder_get_name(encoder));
+		return false;
+	}
+	if (os_atomic_load_bool(&encoder->video_mix_removal_pending)) {
+		blog(LOG_ERROR, "obs_encoder_set_group: encoder '%s' is stopping for video mix removal",
+		     obs_encoder_get_name(encoder));
 		return false;
 	}
 

--- a/libobs/obs-encoder.c
+++ b/libobs/obs-encoder.c
@@ -2393,7 +2393,12 @@ void obs_encoder_group_destroy(obs_encoder_group_t *group)
 
 bool obs_encoder_video_tex_active(const obs_encoder_t *encoder, enum video_format format)
 {
+	if (!encoder || !encoder->media)
+		return false;
+
 	struct obs_core_video_mix *mix = get_mix_for_video(encoder->media);
+	if (!mix)
+		return false;
 
 	if (format == VIDEO_FORMAT_NV12)
 		return mix->using_nv12_tex;

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -400,10 +400,6 @@ struct obs_core_video_mix {
 	float color_matrix[16];
 
 	enum obs_core_video_mix_kind kind;
-	/* Keep the mix-local frame rate instead of synchronizing it with the main
-	 * canvas. Auxiliary mixes set this, ordinary mixes do not, and encoder-only
-	 * mixes inherit the setting from their source mix. */
-	bool preserve_frame_rate;
 
 	long encoder_refs;
 
@@ -415,8 +411,7 @@ extern struct obs_core_video_mix *obs_create_video_mix(struct obs_video_info *ov
  * use canvas_ovi as their canvas identity. Registered identities are retained. */
 extern struct obs_core_video_mix *obs_create_video_mix_internal(const struct obs_video_info *render_info,
 								struct obs_video_info *canvas_ovi,
-								enum obs_core_video_mix_kind kind,
-								bool preserve_frame_rate);
+								enum obs_core_video_mix_kind kind);
 extern void obs_free_video_mix(struct obs_core_video_mix *video);
 extern void obs_encoder_release_video_mix_references(struct obs_core_video_mix *mix);
 /* Returns a published mix for video. The caller must hold mixes_mutex. */

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -388,6 +388,10 @@ struct obs_core_video_mix {
 	 * registered canvas identity. They are returned directly to their
 	 * creator and must not participate in ordinary mix discovery. */
 	bool auxiliary_mix;
+	/* Tracks ownership of the auxiliary reference on canvas_ovi. Unlike
+	 * ordinary mixes, an auxiliary mix can remain in the asynchronous render
+	 * teardown after its caller releases it, so the registered identity must
+	 * stay alive until obs_free_video_mix() releases that reference. */
 	bool retains_canvas_identity;
 	/* Preserve the mix-local FPS instead of synchronizing it with the main
 	 * canvas. Encoder-only mixes inherit this from their source mix. */

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -400,11 +400,9 @@ struct obs_core_video_mix {
 	float color_matrix[16];
 
 	enum obs_core_video_mix_kind kind;
-	/* True while this mix owns an auxiliary reference to canvas_ovi.
-	 * obs_free_video_mix() releases the reference. */
-	bool retains_canvas_identity;
 	/* Keep the mix-local frame rate instead of synchronizing it with the main
-	 * canvas. Encoder-only mixes inherit this setting from their source mix. */
+	 * canvas. Auxiliary mixes set this, ordinary mixes do not, and encoder-only
+	 * mixes inherit the setting from their source mix. */
 	bool preserve_frame_rate;
 
 	long encoder_refs;
@@ -413,15 +411,20 @@ struct obs_core_video_mix {
 };
 
 extern struct obs_core_video_mix *obs_create_video_mix(struct obs_video_info *ovi);
-extern struct obs_core_video_mix *
-obs_create_video_mix_with_frame_rate(struct obs_video_info *ovi,
-				     bool preserve_frame_rate);
+/* Creates a mix of the requested kind. Non-ordinary mixes copy render_info and
+ * retain canvas_ovi as their registered canvas identity. */
+extern struct obs_core_video_mix *obs_create_video_mix_internal(const struct obs_video_info *render_info,
+								struct obs_video_info *canvas_ovi,
+								enum obs_core_video_mix_kind kind,
+								bool preserve_frame_rate);
 extern void obs_free_video_mix(struct obs_core_video_mix *video);
 extern void obs_encoder_release_video_mix_references(struct obs_core_video_mix *mix);
+/* Returns a published mix for video. The caller must hold mixes_mutex. */
+extern struct obs_core_video_mix *get_mix_for_video_locked(video_t *video);
 extern bool obs_video_info_add_sceneitem_ref(struct obs_video_info *ovi);
 extern void obs_video_info_release_sceneitem_ref(struct obs_video_info *ovi);
-extern bool obs_video_info_add_auxiliary_mix_ref(struct obs_video_info *ovi);
-extern void obs_video_info_release_auxiliary_mix_ref(struct obs_video_info *ovi);
+extern bool obs_video_info_add_non_ordinary_mix_ref(struct obs_video_info *ovi);
+extern void obs_video_info_release_non_ordinary_mix_ref(struct obs_video_info *ovi);
 
 struct obs_core_video {
 	graphics_t *graphics;
@@ -472,6 +475,8 @@ struct obs_core_video {
 	DARRAY(obs_weak_encoder_t *) ready_encoder_groups;
 
 	pthread_mutex_t mixes_mutex;
+	/* Serializes encoder teardown for detached video mixes. */
+	pthread_mutex_t mix_cleanup_mutex;
 	DARRAY(struct obs_core_video_mix *) mixes;
 };
 
@@ -658,9 +663,7 @@ extern bool obs_graphics_thread_loop_autorelease(struct obs_graphics_context *co
 
 extern gs_effect_t *obs_load_effect(gs_effect_t **effect, const char *file);
 
-extern bool audio_callback(void *param, uint64_t start_ts_in,
-			   uint64_t end_ts_in, uint64_t *out_ts,
-			   uint32_t mixers,
+extern bool audio_callback(void *param, uint64_t start_ts_in, uint64_t end_ts_in, uint64_t *out_ts, uint32_t mixers,
 			   struct audio_data_mixes_outputs *mixes);
 
 extern void cache_multiple_rendering(void);
@@ -1083,17 +1086,13 @@ struct obs_source {
 	obs_weak_canvas_t *canvas;
 };
 
-extern void set_source_audio_output_buf_size(struct obs_source *source,
-					     size_t canvases);
-extern float *get_source_audio_output_buf(const struct obs_source *source,
-					  size_t canvas_idx, size_t mix_idx,
+extern void set_source_audio_output_buf_size(struct obs_source *source, size_t canvases);
+extern float *get_source_audio_output_buf(const struct obs_source *source, size_t canvas_idx, size_t mix_idx,
 					  size_t channel_idx);
-extern void set_source_audio_output_buf(struct obs_source *source,
-					size_t canvas_idx, size_t mix_idx,
+extern void set_source_audio_output_buf(struct obs_source *source, size_t canvas_idx, size_t mix_idx,
 					size_t channel_idx, float *buf);
 extern void bfree_source_audio_output_buf(struct obs_source *source);
-extern void source_audio_mix_data_init(struct audio_data_mixes_outputs *mix,
-				       size_t canvases);
+extern void source_audio_mix_data_init(struct audio_data_mixes_outputs *mix, size_t canvases);
 extern void source_audio_mix_data_release(struct audio_data_mixes_outputs *mix);
 extern void source_audio_mix_data_clean(struct audio_data_mixes_outputs *mix);
 extern size_t get_audio_outputs_reqired();
@@ -1455,6 +1454,9 @@ struct obs_encoder {
 	struct obs_encoder_info orig_info;
 
 	pthread_mutex_t init_mutex;
+	/* Serializes video-mix cleanup while init_mutex is temporarily released
+	 * to stop outputs. */
+	pthread_mutex_t video_mix_removal_mutex;
 
 	uint32_t samplerate;
 	size_t planes;
@@ -1475,6 +1477,8 @@ struct obs_encoder {
 
 	volatile bool active;
 	volatile bool paused;
+	/* Blocks normal encoder operations during video-mix cleanup. */
+	volatile bool video_mix_removal_pending;
 	bool initialized;
 
 	/* indicates ownership of the info.id buffer */
@@ -1524,7 +1528,7 @@ struct obs_encoder {
 
 	/* stores the video/audio media output pointer.  video_t *or audio_t **/
 	void *media;
-	/* Stores the original video if GPU scaling is enabled and `media` can be overwritten. */
+	/* Restore target and ownership marker for an encoder-only GPU rescale mix. */
 	video_t *original_video;
 
 	pthread_mutex_t callbacks_mutex;
@@ -1547,14 +1551,12 @@ extern struct obs_encoder_info *find_encoder(const char *id);
 extern bool obs_encoder_initialize(obs_encoder_t *encoder);
 extern void obs_encoder_shutdown(obs_encoder_t *encoder);
 
-extern void obs_encoder_start(obs_encoder_t *encoder,
-			      encoded_callback_t new_packet,
-			      void *param);
-extern void obs_encoder_stop(obs_encoder_t *encoder,
-			     encoded_callback_t new_packet,
-			     void *param);
+/* Starts an encoder only if teardown has not reserved it. */
+extern bool obs_encoder_start_if_ready(obs_encoder_t *encoder, encoded_callback_t new_packet, void *param);
+extern void obs_encoder_start(obs_encoder_t *encoder, encoded_callback_t new_packet, void *param);
+extern void obs_encoder_stop(obs_encoder_t *encoder, encoded_callback_t new_packet, void *param);
 
-extern void obs_encoder_add_output(struct obs_encoder *encoder, struct obs_output *output);
+extern bool obs_encoder_add_output(struct obs_encoder *encoder, struct obs_output *output);
 extern void obs_encoder_remove_output(struct obs_encoder *encoder, struct obs_output *output);
 
 extern bool start_gpu_encode(obs_encoder_t *encoder);

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -388,7 +388,7 @@ struct obs_core_video_mix {
 
 	video_t *video;
 	struct obs_video_info ovi;         /* Mix-local render settings. */
-	struct obs_video_info *canvas_ovi; /* Stable public canvas identity for lookups/routing. */
+	struct obs_video_info *canvas_ovi; /* Stable canvas identity for lookups/routing; may be canvas-owned. */
 	enum obs_video_rendering_mode rendering_mode;
 
 	bool gpu_conversion;
@@ -412,7 +412,7 @@ struct obs_core_video_mix {
 
 extern struct obs_core_video_mix *obs_create_video_mix(struct obs_video_info *ovi);
 /* Creates a mix of the requested kind. Non-ordinary mixes copy render_info and
- * retain canvas_ovi as their registered canvas identity. */
+ * use canvas_ovi as their canvas identity. Registered identities are retained. */
 extern struct obs_core_video_mix *obs_create_video_mix_internal(const struct obs_video_info *render_info,
 								struct obs_video_info *canvas_ovi,
 								enum obs_core_video_mix_kind kind,
@@ -423,8 +423,6 @@ extern void obs_encoder_release_video_mix_references(struct obs_core_video_mix *
 extern struct obs_core_video_mix *get_mix_for_video_locked(video_t *video);
 extern bool obs_video_info_add_sceneitem_ref(struct obs_video_info *ovi);
 extern void obs_video_info_release_sceneitem_ref(struct obs_video_info *ovi);
-extern bool obs_video_info_add_non_ordinary_mix_ref(struct obs_video_info *ovi);
-extern void obs_video_info_release_non_ordinary_mix_ref(struct obs_video_info *ovi);
 
 struct obs_core_video {
 	graphics_t *graphics;

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -384,6 +384,15 @@ struct obs_core_video_mix {
 
 	float color_matrix[16];
 
+	/* Auxiliary mixes render with private settings while borrowing a
+	 * registered canvas identity. They are returned directly to their
+	 * creator and must not participate in ordinary mix discovery. */
+	bool auxiliary_mix;
+	bool retains_canvas_identity;
+	/* Preserve the mix-local FPS instead of synchronizing it with the main
+	 * canvas. Encoder-only mixes inherit this from their source mix. */
+	bool preserve_frame_rate;
+
 	bool encoder_only_mix;
 	long encoder_refs;
 
@@ -391,10 +400,15 @@ struct obs_core_video_mix {
 };
 
 extern struct obs_core_video_mix *obs_create_video_mix(struct obs_video_info *ovi);
+extern struct obs_core_video_mix *
+obs_create_video_mix_with_frame_rate(struct obs_video_info *ovi,
+				     bool preserve_frame_rate);
 extern void obs_free_video_mix(struct obs_core_video_mix *video);
 extern void obs_encoder_release_video_mix_references(struct obs_core_video_mix *mix);
 extern bool obs_video_info_add_sceneitem_ref(struct obs_video_info *ovi);
 extern void obs_video_info_release_sceneitem_ref(struct obs_video_info *ovi);
+extern bool obs_video_info_add_auxiliary_mix_ref(struct obs_video_info *ovi);
+extern void obs_video_info_release_auxiliary_mix_ref(struct obs_video_info *ovi);
 
 struct obs_core_video {
 	graphics_t *graphics;

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -333,18 +333,18 @@ struct obs_task_info {
 	void *param;
 };
 
-/* Describes how a core video mix is published, accessed, and owned. */
+/* Identifies the role of a core video mix. */
 enum obs_core_video_mix_kind {
-	/* A published application canvas mix that participates in ordinary mix
-	 * discovery. Keep this value at zero so zero-initialized mixes use the
-	 * default kind. */
+	/* An ordinary video mix eligible for obs_video_mix_get() and
+	 * obs_view_enum_video_info(). Keep this value at zero so zero-initialized
+	 * mixes use this kind. */
 	OBS_CORE_VIDEO_MIX_KIND_ORDINARY = 0,
-	/* A private render mix that borrows a registered ordinary mix's canvas
-	 * identity for scene filtering and audio routing, and is accessed only
-	 * through the handle returned to its creator. */
+	/* An auxiliary video mix that uses an ordinary mix's canvas identity for
+	 * scene filtering and audio routing. Excluded from obs_video_mix_get() and
+	 * obs_view_enum_video_info(). */
 	OBS_CORE_VIDEO_MIX_KIND_AUXILIARY,
-	/* A private scaling or conversion mix created and owned by video encoders,
-	 * and excluded from ordinary mix discovery. */
+	/* A scaling or conversion video mix managed by encoders and excluded from
+	 * obs_video_mix_get() and obs_view_enum_video_info(). */
 	OBS_CORE_VIDEO_MIX_KIND_ENCODER_ONLY,
 };
 
@@ -399,17 +399,12 @@ struct obs_core_video_mix {
 
 	float color_matrix[16];
 
-	/* Auxiliary mixes are returned directly to their creator, while
-	 * encoder-only mixes are implementation details of scaled encoders.
-	 * Neither kind participates in ordinary mix discovery. */
 	enum obs_core_video_mix_kind kind;
-	/* Tracks ownership of the auxiliary reference on canvas_ovi. Unlike
-	 * ordinary mixes, an auxiliary mix can remain in the asynchronous render
-	 * teardown after its caller releases it, so the registered identity must
-	 * stay alive until obs_free_video_mix() releases that reference. */
+	/* True while this mix owns an auxiliary reference to canvas_ovi.
+	 * obs_free_video_mix() releases the reference. */
 	bool retains_canvas_identity;
-	/* Preserve the mix-local FPS instead of synchronizing it with the main
-	 * canvas. Encoder-only mixes inherit this from their source mix. */
+	/* Keep the mix-local frame rate instead of synchronizing it with the main
+	 * canvas. Encoder-only mixes inherit this setting from their source mix. */
 	bool preserve_frame_rate;
 
 	long encoder_refs;
@@ -672,7 +667,7 @@ extern void cache_multiple_rendering(void);
 extern bool get_cached_multiple_rendering(void);
 
 extern struct obs_core_video_mix *get_mix_for_video(video_t *video);
-/* Use to set the active video render context for the current render pass. */
+/* Sets the active video mix for the current render pass. */
 extern void obs_set_video_render_context(struct obs_core_video_mix *mix);
 
 extern void start_raw_video(video_t *video, const struct video_scale_info *conversion, uint32_t frame_rate_divisor,

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -333,6 +333,21 @@ struct obs_task_info {
 	void *param;
 };
 
+/* Describes how a core video mix is published, accessed, and owned. */
+enum obs_core_video_mix_kind {
+	/* A published application canvas mix that participates in ordinary mix
+	 * discovery. Keep this value at zero so zero-initialized mixes use the
+	 * default kind. */
+	OBS_CORE_VIDEO_MIX_KIND_ORDINARY = 0,
+	/* A private render mix that borrows a registered ordinary mix's canvas
+	 * identity for scene filtering and audio routing, and is accessed only
+	 * through the handle returned to its creator. */
+	OBS_CORE_VIDEO_MIX_KIND_AUXILIARY,
+	/* A private scaling or conversion mix created and owned by video encoders,
+	 * and excluded from ordinary mix discovery. */
+	OBS_CORE_VIDEO_MIX_KIND_ENCODER_ONLY,
+};
+
 struct obs_core_video_mix {
 	struct obs_view *view;
 
@@ -384,10 +399,10 @@ struct obs_core_video_mix {
 
 	float color_matrix[16];
 
-	/* Auxiliary mixes render with private settings while borrowing a
-	 * registered canvas identity. They are returned directly to their
-	 * creator and must not participate in ordinary mix discovery. */
-	bool auxiliary_mix;
+	/* Auxiliary mixes are returned directly to their creator, while
+	 * encoder-only mixes are implementation details of scaled encoders.
+	 * Neither kind participates in ordinary mix discovery. */
+	enum obs_core_video_mix_kind kind;
 	/* Tracks ownership of the auxiliary reference on canvas_ovi. Unlike
 	 * ordinary mixes, an auxiliary mix can remain in the asynchronous render
 	 * teardown after its caller releases it, so the registered identity must
@@ -397,7 +412,6 @@ struct obs_core_video_mix {
 	 * canvas. Encoder-only mixes inherit this from their source mix. */
 	bool preserve_frame_rate;
 
-	bool encoder_only_mix;
 	long encoder_refs;
 
 	bool mix_audio;

--- a/libobs/obs-output.c
+++ b/libobs/obs-output.c
@@ -1092,11 +1092,17 @@ void obs_output_set_video_encoder2(obs_output_t *output, obs_encoder_t *encoder,
 	if (output->video_encoders[idx] == encoder)
 		return;
 
+	obs_encoder_t *new_encoder = obs_encoder_get_ref(encoder);
+	if (new_encoder && !obs_encoder_add_output(new_encoder, output)) {
+		blog(LOG_WARNING, "%s: encoder '%s' is stopping for video mix removal", __FUNCTION__,
+		     obs_encoder_get_name(new_encoder));
+		obs_encoder_release(new_encoder);
+		return;
+	}
+
 	obs_encoder_remove_output(output->video_encoders[idx], output);
 	obs_encoder_release(output->video_encoders[idx]);
-
-	output->video_encoders[idx] = obs_encoder_get_ref(encoder);
-	obs_encoder_add_output(output->video_encoders[idx], output);
+	output->video_encoders[idx] = new_encoder;
 
 	destroy_caption_track(&output->caption_tracks[idx]);
 	if (encoder != NULL) {
@@ -1154,11 +1160,17 @@ void obs_output_set_audio_encoder(obs_output_t *output, obs_encoder_t *encoder, 
 	if (output->audio_encoders[idx] == encoder)
 		return;
 
+	obs_encoder_t *new_encoder = obs_encoder_get_ref(encoder);
+	if (new_encoder && !obs_encoder_add_output(new_encoder, output)) {
+		blog(LOG_WARNING, "%s: encoder '%s' is stopping for video mix removal", __FUNCTION__,
+		     obs_encoder_get_name(new_encoder));
+		obs_encoder_release(new_encoder);
+		return;
+	}
+
 	obs_encoder_remove_output(output->audio_encoders[idx], output);
 	obs_encoder_release(output->audio_encoders[idx]);
-
-	output->audio_encoders[idx] = obs_encoder_get_ref(encoder);
-	obs_encoder_add_output(output->audio_encoders[idx], output);
+	output->audio_encoders[idx] = new_encoder;
 }
 
 obs_encoder_t *obs_output_get_video_encoder2(const obs_output_t *output, size_t idx)
@@ -2477,21 +2489,41 @@ static void default_raw_audio_callback(void *param, size_t mix_idx, struct audio
 	}
 }
 
-static inline void start_audio_encoders(struct obs_output *output, encoded_callback_t encoded_callback)
+static inline bool start_audio_encoders(struct obs_output *output, encoded_callback_t encoded_callback)
 {
 	for (size_t i = 0; i < MAX_OUTPUT_AUDIO_ENCODERS; i++) {
-		if (output->audio_encoders[i]) {
-			obs_encoder_start(output->audio_encoders[i], encoded_callback, output);
-		}
+		if (output->audio_encoders[i] &&
+		    !obs_encoder_start_if_ready(output->audio_encoders[i], encoded_callback, output))
+			return false;
+	}
+	return true;
+}
+
+static inline bool start_video_encoders(struct obs_output *output, encoded_callback_t encoded_callback)
+{
+	for (size_t i = 0; i < MAX_OUTPUT_VIDEO_ENCODERS; i++) {
+		if (output->video_encoders[i] &&
+		    !obs_encoder_start_if_ready(output->video_encoders[i], encoded_callback, output))
+			return false;
+	}
+	return true;
+}
+
+static inline void stop_audio_encoders(obs_output_t *output, encoded_callback_t encoded_callback)
+{
+	for (size_t i = 0; i < MAX_OUTPUT_AUDIO_ENCODERS; i++) {
+		obs_encoder_t *audio = output->audio_encoders[i];
+		if (audio)
+			obs_encoder_stop(audio, encoded_callback, output);
 	}
 }
 
-static inline void start_video_encoders(struct obs_output *output, encoded_callback_t encoded_callback)
+static inline void stop_video_encoders(obs_output_t *output, encoded_callback_t encoded_callback)
 {
 	for (size_t i = 0; i < MAX_OUTPUT_VIDEO_ENCODERS; i++) {
-		if (output->video_encoders[i]) {
-			obs_encoder_start(output->video_encoders[i], encoded_callback, output);
-		}
+		obs_encoder_t *video = output->video_encoders[i];
+		if (video)
+			obs_encoder_stop(video, encoded_callback, output);
 	}
 }
 
@@ -2535,7 +2567,7 @@ static inline bool preserve_active(struct obs_output *output)
 	return (output->delay_flags & OBS_OUTPUT_DELAY_PRESERVE) != 0;
 }
 
-static void hook_data_capture(struct obs_output *output)
+static bool hook_data_capture(struct obs_output *output)
 {
 	encoded_callback_t encoded_callback;
 	bool has_video = flag_video(output);
@@ -2561,10 +2593,17 @@ static void hook_data_capture(struct obs_output *output)
 			     output->context.name, output->delay_sec, preserve_active(output) ? "on" : "off");
 		}
 
-		if (has_audio)
-			start_audio_encoders(output, encoded_callback);
-		if (has_video)
-			start_video_encoders(output, encoded_callback);
+		if ((has_audio && !start_audio_encoders(output, encoded_callback)) ||
+		    (has_video && !start_video_encoders(output, encoded_callback))) {
+			if (has_video)
+				stop_video_encoders(output, encoded_callback);
+			if (has_audio)
+				stop_audio_encoders(output, encoded_callback);
+			os_atomic_set_bool(&output->delay_active, false);
+			if (output->active_delay_ns)
+				obs_output_cleanup_delay(output);
+			return false;
+		}
 	} else {
 		if (has_video)
 			start_raw_video(output->video, obs_output_get_video_conversion(output), 1,
@@ -2572,6 +2611,8 @@ static void hook_data_capture(struct obs_output *output)
 		if (has_audio)
 			start_raw_audio(output);
 	}
+
+	return true;
 }
 
 static inline void signal_start(struct obs_output *output)
@@ -2655,43 +2696,133 @@ static inline bool initialize_video_encoders(obs_output_t *output)
 	return true;
 }
 
-static inline void pair_encoders(obs_output_t *output)
+static struct obs_core_video_mix *get_audio_routing_mix_locked(struct obs_encoder *video)
+{
+	struct obs_core_video_mix *mix = get_mix_for_video_locked(video->media);
+	if (!mix || mix != video->video)
+		return NULL;
+
+	if (mix->kind != OBS_CORE_VIDEO_MIX_KIND_ENCODER_ONLY)
+		return mix;
+
+	struct obs_core_video_mix *source = get_mix_for_video_locked(video->original_video);
+	if (!source || source->kind == OBS_CORE_VIDEO_MIX_KIND_ENCODER_ONLY || source->canvas_ovi != mix->canvas_ovi)
+		return NULL;
+
+	return source;
+}
+
+static bool encoder_array_contains(struct obs_encoder **encoders, size_t count, const struct obs_encoder *encoder)
+{
+	for (size_t i = 0; i < count; i++) {
+		if (encoders[i] == encoder)
+			return true;
+	}
+	return false;
+}
+
+static void sort_encoder_array(struct obs_encoder **encoders, size_t count)
+{
+	for (size_t i = 1; i < count; i++) {
+		struct obs_encoder *encoder = encoders[i];
+		size_t pos = i;
+		while (pos && (uintptr_t)encoders[pos - 1] > (uintptr_t)encoder) {
+			encoders[pos] = encoders[pos - 1];
+			pos--;
+		}
+		encoders[pos] = encoder;
+	}
+}
+
+static size_t collect_pairing_locks(obs_output_t *output, struct obs_encoder **encoders)
+{
+	size_t count = 0;
+	for (size_t i = 0; i < MAX_OUTPUT_VIDEO_ENCODERS; i++) {
+		struct obs_encoder *video = output->video_encoders[i];
+		if (video && !encoder_array_contains(encoders, count, video))
+			encoders[count++] = video;
+	}
+	for (size_t i = 0; i < MAX_OUTPUT_AUDIO_ENCODERS; i++) {
+		struct obs_encoder *audio = output->audio_encoders[i];
+		if (audio && !encoder_array_contains(encoders, count, audio))
+			encoders[count++] = audio;
+	}
+	sort_encoder_array(encoders, count);
+	return count;
+}
+
+static void lock_pairing_encoders(struct obs_encoder **encoders, size_t count)
+{
+	for (size_t i = 0; i < count; i++)
+		pthread_mutex_lock(&encoders[i]->init_mutex);
+}
+
+static void unlock_pairing_encoders(struct obs_encoder **encoders, size_t count)
+{
+	while (count)
+		pthread_mutex_unlock(&encoders[--count]->init_mutex);
+}
+
+static inline bool pair_encoders(obs_output_t *output)
 {
 	size_t first_venc_idx;
 	if (!get_first_video_encoder_index(output, &first_venc_idx))
-		return;
+		return true;
 	struct obs_encoder *video = output->video_encoders[first_venc_idx];
 
-	pthread_mutex_lock(&video->init_mutex);
-	if (video->active) {
-		pthread_mutex_unlock(&video->init_mutex);
-		return;
-	}
+	struct obs_encoder *encoders[MAX_OUTPUT_VIDEO_ENCODERS + MAX_OUTPUT_AUDIO_ENCODERS];
+	size_t encoder_count = collect_pairing_locks(output, encoders);
+	lock_pairing_encoders(encoders, encoder_count);
 
+	bool success = true;
+	for (size_t i = 0; i < encoder_count; i++) {
+		if (os_atomic_load_bool(&encoders[i]->video_mix_removal_pending) || !encoders[i]->context.data ||
+		    !encoders[i]->media) {
+			success = false;
+			goto unlock;
+		}
+	}
+	if (video->active)
+		goto unlock;
+
+	struct obs_encoder *to_pair[MAX_OUTPUT_AUDIO_ENCODERS];
+	size_t num_to_pair = 0;
 	for (size_t i = 0; i < MAX_OUTPUT_AUDIO_ENCODERS; i++) {
 		struct obs_encoder *audio = output->audio_encoders[i];
-		if (!audio)
+		if (!audio || audio->active || audio->paired_encoders.num ||
+		    encoder_array_contains(to_pair, num_to_pair, audio))
 			continue;
 
-		pthread_mutex_lock(&audio->init_mutex);
-		if (!audio->active && !audio->paired_encoders.num) {
-			obs_weak_encoder_t *weak_audio = obs_encoder_get_weak_encoder(audio);
-			obs_weak_encoder_t *weak_video = obs_encoder_get_weak_encoder(video);
-			da_push_back(video->paired_encoders, &weak_audio);
-			da_push_back(audio->paired_encoders, &weak_video);
-
-			/*
-			 * Audio output routing is canvas-aware. In multi-canvas sessions an
-			 * audio encoder without an associated video mix gets fed once per
-			 * canvas, which duplicates audio blocks at the same timestamp. Have
-			 * the audio encoder follow the paired video encoder's canvas so it
-			 * only receives the intended mix.
-			 */
-			audio->video = video->video;
-		}
-		pthread_mutex_unlock(&audio->init_mutex);
+		to_pair[num_to_pair++] = audio;
 	}
-	pthread_mutex_unlock(&video->init_mutex);
+	if (!num_to_pair)
+		goto unlock;
+
+	pthread_mutex_lock(&obs->video.mixes_mutex);
+	struct obs_core_video_mix *routing_mix = get_audio_routing_mix_locked(video);
+	pthread_mutex_unlock(&obs->video.mixes_mutex);
+	if (!routing_mix) {
+		blog(LOG_ERROR, "Failed to pair encoders: video source mix is no longer available");
+		success = false;
+		goto unlock;
+	}
+
+	/* Audio routing is canvas-aware. Pair each audio encoder with the video
+	 * encoder's source mix so it receives one block per timestamp. Temporary
+	 * encoder-only rescale mixes do not own audio routing. */
+	for (size_t i = 0; i < num_to_pair; i++) {
+		struct obs_encoder *audio = to_pair[i];
+		audio->video = routing_mix;
+		obs_weak_encoder_t *weak_audio = obs_encoder_get_weak_encoder(audio);
+		obs_weak_encoder_t *weak_video = obs_encoder_get_weak_encoder(video);
+		da_push_back(video->paired_encoders, &weak_audio);
+		da_push_back(audio->paired_encoders, &weak_video);
+	}
+
+unlock:
+	unlock_pairing_encoders(encoders, encoder_count);
+
+	return success;
 }
 
 bool obs_output_initialize_encoders(obs_output_t *output, uint32_t flags)
@@ -2914,9 +3045,6 @@ bool obs_output_begin_data_capture(obs_output_t *output, uint32_t flags)
 	if (!can_begin_data_capture(output))
 		return false;
 
-	if (flag_video(output) && flag_audio(output))
-		pair_encoders(output);
-
 	size_t batch_size;
 	if (!calculate_batch_size(output, &batch_size)) {
 		// Abort before activation so callers get a clean start failure instead of a partial capture state.
@@ -2926,8 +3054,14 @@ bool obs_output_begin_data_capture(obs_output_t *output, uint32_t flags)
 	// Batch size is recomputed for each start, so overwrite the previous value instead of accumulating it.
 	output->interleaver_max_batch_size = batch_size;
 
+	if (flag_video(output) && flag_audio(output) && !pair_encoders(output))
+		return false;
+
 	os_atomic_set_bool(&output->data_active, true);
-	hook_data_capture(output);
+	if (!hook_data_capture(output)) {
+		os_atomic_set_bool(&output->data_active, false);
+		return false;
+	}
 
 	if (flag_service(output))
 		obs_service_activate(output->service);
@@ -2947,24 +3081,6 @@ bool obs_output_begin_data_capture(obs_output_t *output, uint32_t flags)
 	}
 
 	return true;
-}
-
-static inline void stop_audio_encoders(obs_output_t *output, encoded_callback_t encoded_callback)
-{
-	for (size_t i = 0; i < MAX_OUTPUT_AUDIO_ENCODERS; i++) {
-		obs_encoder_t *audio = output->audio_encoders[i];
-		if (audio)
-			obs_encoder_stop(audio, encoded_callback, output);
-	}
-}
-
-static inline void stop_video_encoders(obs_output_t *output, encoded_callback_t encoded_callback)
-{
-	for (size_t i = 0; i < MAX_OUTPUT_VIDEO_ENCODERS; i++) {
-		obs_encoder_t *video = output->video_encoders[i];
-		if (video)
-			obs_encoder_stop(video, encoded_callback, output);
-	}
 }
 
 static inline void stop_raw_audio(obs_output_t *output)

--- a/libobs/obs-view.c
+++ b/libobs/obs-view.c
@@ -169,19 +169,14 @@ video_t *obs_view_add2(obs_view_t *view, struct obs_video_info *ovi)
 	return mix->video;
 }
 
-obs_core_video_mix_t *
-obs_view_add_auxiliary_mix(obs_view_t *view,
-			   const struct obs_video_info *render_info,
-			   obs_core_video_mix_t *identity_source_mix)
+obs_core_video_mix_t *obs_view_add_auxiliary_mix(obs_view_t *view, const struct obs_video_info *render_info,
+						 obs_core_video_mix_t *identity_source_mix)
 {
-	if (!obs || !obs->video.graphics || !view || !render_info ||
-	    !identity_source_mix)
+	if (!obs || !obs->video.graphics || !view || !render_info || !identity_source_mix)
 		return NULL;
 
-	struct obs_video_info render_settings = *render_info;
 	struct obs_video_info *canvas_identity = NULL;
-	enum obs_video_rendering_mode rendering_mode =
-		OBS_MAIN_VIDEO_RENDERING;
+	enum obs_video_rendering_mode rendering_mode = OBS_MAIN_VIDEO_RENDERING;
 
 	/* Verify that identity_source_mix is still in the mix list before
 	 * dereferencing it. Only an attached ordinary mix can supply the canvas
@@ -191,8 +186,7 @@ obs_view_add_auxiliary_mix(obs_view_t *view,
 		struct obs_core_video_mix *mix = obs->video.mixes.array[i];
 		if (mix != identity_source_mix)
 			continue;
-		if (mix->view &&
-		    mix->kind == OBS_CORE_VIDEO_MIX_KIND_ORDINARY) {
+		if (mix->view && mix->kind == OBS_CORE_VIDEO_MIX_KIND_ORDINARY) {
 			canvas_identity = mix->canvas_ovi;
 			rendering_mode = mix->rendering_mode;
 		}
@@ -200,24 +194,16 @@ obs_view_add_auxiliary_mix(obs_view_t *view,
 	}
 	pthread_mutex_unlock(&obs->video.mixes_mutex);
 
-	/* Prevent the registered video info from being removed until the auxiliary
-	 * mix is destroyed. */
-	if (!canvas_identity ||
-	    !obs_video_info_add_auxiliary_mix_ref(canvas_identity))
+	if (!canvas_identity)
 		return NULL;
 
 	struct obs_core_video_mix *mix =
-		obs_create_video_mix_with_frame_rate(&render_settings, true);
-	if (!mix) {
-		obs_video_info_release_auxiliary_mix_ref(canvas_identity);
+		obs_create_video_mix_internal(render_info, canvas_identity, OBS_CORE_VIDEO_MIX_KIND_AUXILIARY, true);
+	if (!mix)
 		return NULL;
-	}
 
 	mix->view = view;
-	mix->canvas_ovi = canvas_identity;
 	mix->rendering_mode = rendering_mode;
-	mix->kind = OBS_CORE_VIDEO_MIX_KIND_AUXILIARY;
-	mix->retains_canvas_identity = true;
 
 	pthread_mutex_lock(&obs->video.mixes_mutex);
 	da_push_back(obs->video.mixes, &mix);

--- a/libobs/obs-view.c
+++ b/libobs/obs-view.c
@@ -186,7 +186,11 @@ obs_core_video_mix_t *obs_view_add_auxiliary_mix(obs_view_t *view, const struct 
 		struct obs_core_video_mix *mix = obs->video.mixes.array[i];
 		if (mix != identity_source_mix)
 			continue;
-		if (mix->view && mix->kind == OBS_CORE_VIDEO_MIX_KIND_ORDINARY) {
+		const bool cadence_matches = render_info->fps_num && render_info->fps_den && mix->ovi.fps_num &&
+					     mix->ovi.fps_den &&
+					     (uint64_t)render_info->fps_num * mix->ovi.fps_den ==
+						     (uint64_t)mix->ovi.fps_num * render_info->fps_den;
+		if (mix->view && mix->kind == OBS_CORE_VIDEO_MIX_KIND_ORDINARY && cadence_matches) {
 			canvas_identity = mix->canvas_ovi;
 			rendering_mode = mix->rendering_mode;
 		}
@@ -198,7 +202,7 @@ obs_core_video_mix_t *obs_view_add_auxiliary_mix(obs_view_t *view, const struct 
 		return NULL;
 
 	struct obs_core_video_mix *mix =
-		obs_create_video_mix_internal(render_info, canvas_identity, OBS_CORE_VIDEO_MIX_KIND_AUXILIARY, true);
+		obs_create_video_mix_internal(render_info, canvas_identity, OBS_CORE_VIDEO_MIX_KIND_AUXILIARY);
 	if (!mix)
 		return NULL;
 

--- a/libobs/obs-view.c
+++ b/libobs/obs-view.c
@@ -193,8 +193,8 @@ obs_view_add_auxiliary_mix(obs_view_t *view,
 		struct obs_core_video_mix *mix = obs->video.mixes.array[i];
 		if (mix != identity_source_mix)
 			continue;
-		if (mix->view && !mix->encoder_only_mix &&
-		    !mix->auxiliary_mix) {
+		if (mix->view &&
+		    mix->kind == OBS_CORE_VIDEO_MIX_KIND_ORDINARY) {
 			canvas_identity = mix->canvas_ovi;
 			rendering_mode = mix->rendering_mode;
 		}
@@ -218,7 +218,7 @@ obs_view_add_auxiliary_mix(obs_view_t *view,
 	mix->view = view;
 	mix->canvas_ovi = canvas_identity;
 	mix->rendering_mode = rendering_mode;
-	mix->auxiliary_mix = true;
+	mix->kind = OBS_CORE_VIDEO_MIX_KIND_AUXILIARY;
 	mix->retains_canvas_identity = true;
 
 	pthread_mutex_lock(&obs->video.mixes_mutex);
@@ -291,7 +291,7 @@ void obs_view_enum_video_info(obs_view_t *view, bool (*enum_proc)(void *, struct
 		/* Auxiliary mixes alias an existing public identity and are consumed
 		 * through their direct handle, so enumerating them would duplicate the
 		 * identified canvas. */
-		if (mix->encoder_only_mix || mix->auxiliary_mix)
+		if (mix->kind != OBS_CORE_VIDEO_MIX_KIND_ORDINARY)
 			continue;
 		if (!enum_proc(param, mix->canvas_ovi))
 			break;

--- a/libobs/obs-view.c
+++ b/libobs/obs-view.c
@@ -169,6 +169,65 @@ video_t *obs_view_add2(obs_view_t *view, struct obs_video_info *ovi)
 	return mix->video;
 }
 
+obs_core_video_mix_t *
+obs_view_add_auxiliary_mix(obs_view_t *view,
+			   const struct obs_video_info *render_info,
+			   obs_core_video_mix_t *identity_source_mix)
+{
+	if (!obs || !obs->video.graphics || !view || !render_info ||
+	    !identity_source_mix)
+		return NULL;
+
+	/* Copy before doing any validation or allocation so callers can use a
+	 * temporary settings structure without transferring its ownership. */
+	struct obs_video_info render_settings = *render_info;
+	struct obs_video_info *canvas_identity = NULL;
+	enum obs_video_rendering_mode rendering_mode =
+		OBS_MAIN_VIDEO_RENDERING;
+
+	/* Validate the opaque source handle without dereferencing it until it is
+	 * found in the published mix array. Chaining auxiliary/encoder-only
+	 * identities is rejected: the alias must terminate at a real canvas. */
+	pthread_mutex_lock(&obs->video.mixes_mutex);
+	for (size_t i = 0; i < obs->video.mixes.num; i++) {
+		struct obs_core_video_mix *mix = obs->video.mixes.array[i];
+		if (mix != identity_source_mix)
+			continue;
+		if (mix->view && !mix->encoder_only_mix &&
+		    !mix->auxiliary_mix) {
+			canvas_identity = mix->canvas_ovi;
+			rendering_mode = mix->rendering_mode;
+		}
+		break;
+	}
+	pthread_mutex_unlock(&obs->video.mixes_mutex);
+
+	/* The dedicated retention prevents obs_remove_video_info() from freeing
+	 * the aliased identity before this auxiliary mix leaves the render loop. */
+	if (!canvas_identity ||
+	    !obs_video_info_add_auxiliary_mix_ref(canvas_identity))
+		return NULL;
+
+	struct obs_core_video_mix *mix =
+		obs_create_video_mix_with_frame_rate(&render_settings, true);
+	if (!mix) {
+		obs_video_info_release_auxiliary_mix_ref(canvas_identity);
+		return NULL;
+	}
+
+	mix->view = view;
+	mix->canvas_ovi = canvas_identity;
+	mix->rendering_mode = rendering_mode;
+	mix->auxiliary_mix = true;
+	mix->retains_canvas_identity = true;
+
+	pthread_mutex_lock(&obs->video.mixes_mutex);
+	da_push_back(obs->video.mixes, &mix);
+	pthread_mutex_unlock(&obs->video.mixes_mutex);
+
+	return mix;
+}
+
 video_t *obs_stream_view_add(obs_view_t *view, struct obs_video_info *ovi)
 {
 	if (!view)
@@ -229,7 +288,10 @@ void obs_view_enum_video_info(obs_view_t *view, bool (*enum_proc)(void *, struct
 		struct obs_core_video_mix *mix = obs->video.mixes.array[i];
 		if (mix->view != view)
 			continue;
-		if (mix->encoder_only_mix)
+		/* Auxiliary mixes alias an existing public identity and are consumed
+		 * through their direct handle, so enumerating them would duplicate the
+		 * identified canvas. */
+		if (mix->encoder_only_mix || mix->auxiliary_mix)
 			continue;
 		if (!enum_proc(param, mix->canvas_ovi))
 			break;

--- a/libobs/obs-view.c
+++ b/libobs/obs-view.c
@@ -178,16 +178,14 @@ obs_view_add_auxiliary_mix(obs_view_t *view,
 	    !identity_source_mix)
 		return NULL;
 
-	/* Copy before doing any validation or allocation so callers can use a
-	 * temporary settings structure without transferring its ownership. */
 	struct obs_video_info render_settings = *render_info;
 	struct obs_video_info *canvas_identity = NULL;
 	enum obs_video_rendering_mode rendering_mode =
 		OBS_MAIN_VIDEO_RENDERING;
 
-	/* Validate the opaque source handle without dereferencing it until it is
-	 * found in the published mix array. Chaining auxiliary/encoder-only
-	 * identities is rejected: the alias must terminate at a real canvas. */
+	/* Verify that identity_source_mix is still in the mix list before
+	 * dereferencing it. Only an attached ordinary mix can supply the canvas
+	 * identity. */
 	pthread_mutex_lock(&obs->video.mixes_mutex);
 	for (size_t i = 0; i < obs->video.mixes.num; i++) {
 		struct obs_core_video_mix *mix = obs->video.mixes.array[i];
@@ -202,8 +200,8 @@ obs_view_add_auxiliary_mix(obs_view_t *view,
 	}
 	pthread_mutex_unlock(&obs->video.mixes_mutex);
 
-	/* The dedicated retention prevents obs_remove_video_info() from freeing
-	 * the aliased identity before this auxiliary mix leaves the render loop. */
+	/* Prevent the registered video info from being removed until the auxiliary
+	 * mix is destroyed. */
 	if (!canvas_identity ||
 	    !obs_video_info_add_auxiliary_mix_ref(canvas_identity))
 		return NULL;
@@ -288,9 +286,8 @@ void obs_view_enum_video_info(obs_view_t *view, bool (*enum_proc)(void *, struct
 		struct obs_core_video_mix *mix = obs->video.mixes.array[i];
 		if (mix->view != view)
 			continue;
-		/* Auxiliary mixes alias an existing public identity and are consumed
-		 * through their direct handle, so enumerating them would duplicate the
-		 * identified canvas. */
+		/* Auxiliary and encoder-only mixes reuse an ordinary mix's canvas
+		 * identity, so enumerate only ordinary mixes. */
 		if (mix->kind != OBS_CORE_VIDEO_MIX_KIND_ORDINARY)
 			continue;
 		if (!enum_proc(param, mix->canvas_ovi))

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -32,7 +32,7 @@ const bool key_processing_enabled = false;
 struct obs_managed_video_info {
 	struct obs_video_info ovi;
 	size_t scene_item_refs;
-	/* Keeps the registered identity alive while auxiliary mixes borrow it. */
+	/* Number of auxiliary mixes retaining this registered video info. */
 	size_t auxiliary_mix_refs;
 	bool removing;
 };
@@ -2050,9 +2050,9 @@ int obs_remove_video_info(struct obs_video_info *ovi)
 
 	bool found = false;
 
-	/* Mark the video info as removing before deactivating video. Canvas
-	 * assignment and auxiliary identity retention take the same mutex, so no
-	 * new owner can race with the reference checks below. */
+	/* Mark the video info as removing while holding canvases_mutex. Scene items
+	 * and auxiliary mixes acquire references under the same mutex, so no new
+	 * reference can race with the checks below. */
 	pthread_mutex_lock(&obs->video.canvases_mutex);
 	for (size_t i = 0; i < obs->video.canvases.num; i++) {
 		if (obs->video.canvases.array[i] != ovi)
@@ -3121,9 +3121,8 @@ obs_core_video_mix_t *obs_video_mix_get(struct obs_video_info *ovi, enum obs_vid
 	// As this canvas is unused, we can safely skip it.
 	for (size_t i = 1, num = obs->video.mixes.num; i < num; i++) {
 		struct obs_core_video_mix *mix = obs->video.mixes.array[i];
-		/* Auxiliary mixes deliberately share a canvas identity with a normal
-		 * mix. Their creator receives the exact handle, while discovery must
-		 * continue to resolve the application's normal mix. */
+		/* Return only ordinary mixes. Auxiliary and encoder-only mixes can use
+		 * the same canvas identity and rendering mode. */
 		if (!mix || mix->kind != OBS_CORE_VIDEO_MIX_KIND_ORDINARY)
 			continue;
 		if ((mix->canvas_ovi == ovi || ovi == NULL) && mix->rendering_mode == mode) {

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -922,7 +922,12 @@ void obs_free_video_mix(struct obs_core_video_mix *video)
 		video->cur_texture = 0;
 	}
 
+	assert(video->retains_canvas_identity ==
+	       (video->kind == OBS_CORE_VIDEO_MIX_KIND_AUXILIARY));
+	assert(video->kind != OBS_CORE_VIDEO_MIX_KIND_AUXILIARY ||
+	       video->preserve_frame_rate);
 	if (video->retains_canvas_identity) {
+		assert(video->canvas_ovi != NULL);
 		obs_video_info_release_auxiliary_mix_ref(video->canvas_ovi);
 		video->retains_canvas_identity = false;
 	}
@@ -3119,7 +3124,7 @@ obs_core_video_mix_t *obs_video_mix_get(struct obs_video_info *ovi, enum obs_vid
 		/* Auxiliary mixes deliberately share a canvas identity with a normal
 		 * mix. Their creator receives the exact handle, while discovery must
 		 * continue to resolve the application's normal mix. */
-		if (!mix || mix->encoder_only_mix || mix->auxiliary_mix)
+		if (!mix || mix->kind != OBS_CORE_VIDEO_MIX_KIND_ORDINARY)
 			continue;
 		if ((mix->canvas_ovi == ovi || ovi == NULL) && mix->rendering_mode == mode) {
 			result = mix;

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -663,8 +663,7 @@ static int obs_init_video_mix(const struct obs_video_info *ovi, struct obs_core_
 	pthread_mutex_init_value(&video->gpu_encoder_mutex);
 
 	video->ovi = *ovi;
-	if (!video->preserve_frame_rate)
-		sync_mix_fps_with_main_canvas(video);
+	sync_mix_fps_with_main_canvas(video);
 	make_video_info(&vi, &video->ovi);
 
 	video->gpu_conversion = ovi->gpu_conversion;
@@ -706,14 +705,14 @@ fail:
 
 struct obs_core_video_mix *obs_create_video_mix_internal(const struct obs_video_info *render_info,
 							 struct obs_video_info *canvas_ovi,
-							 enum obs_core_video_mix_kind kind, bool preserve_frame_rate)
+							 enum obs_core_video_mix_kind kind)
 {
 	if (!render_info || !canvas_ovi)
 		return NULL;
 
 	switch (kind) {
 	case OBS_CORE_VIDEO_MIX_KIND_ORDINARY:
-		if (preserve_frame_rate || render_info != canvas_ovi)
+		if (render_info != canvas_ovi)
 			return NULL;
 		break;
 	case OBS_CORE_VIDEO_MIX_KIND_ENCODER_ONLY: {
@@ -726,8 +725,7 @@ struct obs_core_video_mix *obs_create_video_mix_internal(const struct obs_video_
 		break;
 	}
 	case OBS_CORE_VIDEO_MIX_KIND_AUXILIARY:
-		if (!preserve_frame_rate ||
-		    obs_video_info_retain_non_ordinary_mix_ref(canvas_ovi) != VIDEO_INFO_RETAINED)
+		if (obs_video_info_retain_non_ordinary_mix_ref(canvas_ovi) != VIDEO_INFO_RETAINED)
 			return NULL;
 		break;
 	default:
@@ -737,7 +735,6 @@ struct obs_core_video_mix *obs_create_video_mix_internal(const struct obs_video_
 	struct obs_core_video_mix *video = bzalloc(sizeof(struct obs_core_video_mix));
 	video->canvas_ovi = canvas_ovi;
 	video->kind = kind;
-	video->preserve_frame_rate = preserve_frame_rate;
 	if (obs_init_video_mix(render_info, video) != OBS_VIDEO_SUCCESS) {
 		obs_free_video_mix(video);
 		return NULL;
@@ -747,7 +744,7 @@ struct obs_core_video_mix *obs_create_video_mix_internal(const struct obs_video_
 
 struct obs_core_video_mix *obs_create_video_mix(struct obs_video_info *ovi)
 {
-	return obs_create_video_mix_internal(ovi, ovi, OBS_CORE_VIDEO_MIX_KIND_ORDINARY, false);
+	return obs_create_video_mix_internal(ovi, ovi, OBS_CORE_VIDEO_MIX_KIND_ORDINARY);
 }
 
 static bool restore_canvases(void)
@@ -965,7 +962,6 @@ void obs_free_video_mix(struct obs_core_video_mix *video)
 	if (video->video)
 		obs_free_video_mix_resources(video, true);
 
-	assert(video->kind != OBS_CORE_VIDEO_MIX_KIND_AUXILIARY || video->preserve_frame_rate);
 	if (video->kind != OBS_CORE_VIDEO_MIX_KIND_ORDINARY) {
 		assert(video->canvas_ovi != NULL);
 		/* Registered identities remain discoverable while retained. An

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -1019,7 +1019,7 @@ static void obs_free_video(bool full_clean)
 				(struct obs_managed_video_info *)obs->video.canvases.array[i];
 			assert(managed->scene_item_refs == 0);
 			assert(managed->auxiliary_mix_refs == 0);
-			bfree(obs->video.canvases.array[i]);
+			bfree(managed);
 			obs->video.canvases.array[i] = NULL;
 		}
 		da_free(obs->video.canvases);

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -32,16 +32,18 @@ const bool key_processing_enabled = false;
 struct obs_managed_video_info {
 	struct obs_video_info ovi;
 	size_t scene_item_refs;
-	/* Number of auxiliary mixes retaining this registered video info. */
-	size_t auxiliary_mix_refs;
+	/* Number of non-ordinary mixes retaining this video info. */
+	size_t non_ordinary_mix_refs;
 	bool removing;
 };
 
 extern void add_default_module_paths(void);
 extern char *find_libobs_data_file(const char *file);
 static void obs_free_graphics(void);
+static void obs_free_render_textures(struct obs_core_video_mix *video);
+static void obs_free_video_mix_resources(struct obs_core_video_mix *video, bool mutex_initialized);
 
-static inline void make_video_info(struct video_output_info *vi, struct obs_video_info *ovi)
+static inline void make_video_info(struct video_output_info *vi, const struct obs_video_info *ovi)
 {
 	vi->name = "video";
 	vi->format = ovi->output_format;
@@ -56,8 +58,7 @@ static inline void make_video_info(struct video_output_info *vi, struct obs_vide
 
 #ifdef _WIN32
 // Fix for missing Windows dependency required by zlib
-EXPORT int __ms_vsnprintf(char *str, size_t size, const char *format,
-			  va_list ap)
+EXPORT int __ms_vsnprintf(char *str, size_t size, const char *format, va_list ap)
 {
 	return vsnprintf(str, size, format, ap);
 }
@@ -443,9 +444,7 @@ static bool obs_init_textures(struct obs_core_video_mix *video)
 	}
 
 	struct obs_video_info *ovi = &video->ovi;
-	video->render_texture = gs_texture_create(ovi->base_width,
-						  ovi->base_height, format, 1,
-						  NULL, GS_RENDER_TARGET);
+	video->render_texture = gs_texture_create(ovi->base_width, ovi->base_height, format, 1, NULL, GS_RENDER_TARGET);
 	if (!video->render_texture)
 		success = false;
 
@@ -627,8 +626,9 @@ static inline void set_video_matrix(struct obs_core_video_mix *video, struct vid
 static void sync_mix_fps_with_main_canvas(struct obs_core_video_mix *video)
 {
 	/* Main view graphics thread drives frame pacing for all views. Keep the
-	 * mix snapshot and the public canvas handle aligned for callers that
-	 * still read fps_num/fps_den from obs_video_info. */
+	 * mix snapshot aligned with it. Ordinary mixes also own the registered
+	 * canvas settings exposed to callers; non-ordinary mixes must not modify
+	 * their canvas identity. */
 	pthread_mutex_lock(&obs->video.mixes_mutex);
 
 	if (obs->video.mixes.num && obs->data.main_canvas->mix) {
@@ -637,7 +637,7 @@ static void sync_mix_fps_with_main_canvas(struct obs_core_video_mix *video)
 		video->ovi.fps_num = main_ovi->fps_num;
 		video->ovi.fps_den = main_ovi->fps_den;
 
-		if (video->canvas_ovi) {
+		if (video->kind == OBS_CORE_VIDEO_MIX_KIND_ORDINARY && video->canvas_ovi) {
 			video->canvas_ovi->fps_num = main_ovi->fps_num;
 			video->canvas_ovi->fps_den = main_ovi->fps_den;
 		}
@@ -646,10 +646,11 @@ static void sync_mix_fps_with_main_canvas(struct obs_core_video_mix *video)
 	pthread_mutex_unlock(&obs->video.mixes_mutex);
 }
 
-static int obs_init_video_mix(struct obs_video_info *ovi,
-			      struct obs_core_video_mix *video)
+static int obs_init_video_mix(const struct obs_video_info *ovi, struct obs_core_video_mix *video)
 {
 	struct video_output_info vi;
+	bool mutex_initialized = false;
+	int result = OBS_VIDEO_FAIL;
 
 	pthread_mutex_init_value(&video->gpu_encoder_mutex);
 
@@ -669,46 +670,70 @@ static int obs_init_video_mix(struct obs_video_info *ovi,
 	if (errorcode != VIDEO_OUTPUT_SUCCESS) {
 		if (errorcode == VIDEO_OUTPUT_INVALIDPARAM) {
 			blog(LOG_ERROR, "Invalid video parameters specified");
-			return OBS_VIDEO_INVALID_PARAM;
+			result = OBS_VIDEO_INVALID_PARAM;
 		} else {
 			blog(LOG_ERROR, "Could not open video output");
 		}
-		return OBS_VIDEO_FAIL;
+		goto fail;
 	}
 
 	if (pthread_mutex_init(&video->gpu_encoder_mutex, NULL) < 0)
-		return OBS_VIDEO_FAIL;
+		goto fail;
+	mutex_initialized = true;
 
 	gs_enter_context(obs->video.graphics);
-
-	if (video->gpu_conversion && !obs_init_gpu_conversion(video))
-		return OBS_VIDEO_FAIL;
-	if (!obs_init_textures(video))
-		return OBS_VIDEO_FAIL;
-
+	bool textures_initialized = (!video->gpu_conversion || obs_init_gpu_conversion(video)) &&
+				    obs_init_textures(video);
 	gs_leave_context();
+	if (!textures_initialized)
+		goto fail;
 
 	return OBS_VIDEO_SUCCESS;
+
+fail:
+	if (video->video)
+		obs_free_video_mix_resources(video, mutex_initialized);
+	return result;
 }
 
-struct obs_core_video_mix *
-obs_create_video_mix_with_frame_rate(struct obs_video_info *ovi,
-				     bool preserve_frame_rate)
+struct obs_core_video_mix *obs_create_video_mix_internal(const struct obs_video_info *render_info,
+							 struct obs_video_info *canvas_ovi,
+							 enum obs_core_video_mix_kind kind, bool preserve_frame_rate)
 {
-	struct obs_core_video_mix *video =
-		bzalloc(sizeof(struct obs_core_video_mix));
-	video->canvas_ovi = ovi;
+	if (!render_info || !canvas_ovi)
+		return NULL;
+
+	switch (kind) {
+	case OBS_CORE_VIDEO_MIX_KIND_ORDINARY:
+		if (preserve_frame_rate || render_info != canvas_ovi)
+			return NULL;
+		break;
+	case OBS_CORE_VIDEO_MIX_KIND_ENCODER_ONLY:
+		if (!obs_video_info_add_non_ordinary_mix_ref(canvas_ovi))
+			return NULL;
+		break;
+	case OBS_CORE_VIDEO_MIX_KIND_AUXILIARY:
+		if (!preserve_frame_rate || !obs_video_info_add_non_ordinary_mix_ref(canvas_ovi))
+			return NULL;
+		break;
+	default:
+		return NULL;
+	}
+
+	struct obs_core_video_mix *video = bzalloc(sizeof(struct obs_core_video_mix));
+	video->canvas_ovi = canvas_ovi;
+	video->kind = kind;
 	video->preserve_frame_rate = preserve_frame_rate;
-	if (obs_init_video_mix(ovi, video) != OBS_VIDEO_SUCCESS) {
-		bfree(video);
-		video = NULL;
+	if (obs_init_video_mix(render_info, video) != OBS_VIDEO_SUCCESS) {
+		obs_free_video_mix(video);
+		return NULL;
 	}
 	return video;
 }
 
 struct obs_core_video_mix *obs_create_video_mix(struct obs_video_info *ovi)
 {
-	return obs_create_video_mix_with_frame_rate(ovi, false);
+	return obs_create_video_mix_internal(ovi, ovi, OBS_CORE_VIDEO_MIX_KIND_ORDINARY, false);
 }
 
 static bool restore_canvases(void)
@@ -754,6 +779,8 @@ static int obs_init_video()
 			return OBS_VIDEO_FAIL;
 		if (pthread_mutex_init(&video->mixes_mutex, NULL) < 0)
 			return OBS_VIDEO_FAIL;
+		if (pthread_mutex_init(&video->mix_cleanup_mutex, NULL) < 0)
+			return OBS_VIDEO_FAIL;
 		if (pthread_mutex_init(&video->canvases_mutex, NULL) < 0)
 			return OBS_VIDEO_FAIL;
 	}
@@ -776,22 +803,17 @@ static int obs_init_video()
 		if (!ovi->initialized)
 			continue;
 
-		if (!have_max_fps ||
-		    (uint64_t)ovi->fps_num * max_fps_den >
-			    (uint64_t)max_fps_num * ovi->fps_den) {
+		if (!have_max_fps || (uint64_t)ovi->fps_num * max_fps_den > (uint64_t)max_fps_num * ovi->fps_den) {
 			max_fps_den = ovi->fps_den;
 			max_fps_num = ovi->fps_num;
 			have_max_fps = true;
 		}
 	}
 
-	video->video_frame_interval_ns =
-		util_mul_div64(1000000000ULL, max_fps_den, max_fps_num);
-	video->video_half_frame_interval_ns =
-		util_mul_div64(500000000ULL, max_fps_den, max_fps_num);
+	video->video_frame_interval_ns = util_mul_div64(1000000000ULL, max_fps_den, max_fps_num);
+	video->video_half_frame_interval_ns = util_mul_div64(500000000ULL, max_fps_den, max_fps_num);
 
-	blog(LOG_INFO, "[VIDEO_CANVAS] init with canvases %zu",
-	     obs->video.canvases.num);
+	blog(LOG_INFO, "[VIDEO_CANVAS] init with canvases %zu", obs->video.canvases.num);
 	for (size_t i = 0, num = obs->video.canvases.num; i < num; i++) {
 		struct obs_video_info *ovi = obs->video.canvases.array[i];
 
@@ -896,40 +918,43 @@ static void obs_free_render_textures(struct obs_core_video_mix *video)
 	gs_leave_context();
 }
 
+static void obs_free_video_mix_resources(struct obs_core_video_mix *video, bool mutex_initialized)
+{
+	if (video->video) {
+		video_output_close(video->video);
+		video->video = NULL;
+	}
+
+	obs_free_render_textures(video);
+
+	deque_free(&video->vframe_info_buffer);
+	deque_free(&video->vframe_info_buffer_gpu);
+
+	video->texture_rendered = false;
+	memset(video->textures_copied, 0, sizeof(video->textures_copied));
+	video->texture_converted = false;
+
+	if (mutex_initialized)
+		pthread_mutex_destroy(&video->gpu_encoder_mutex);
+	pthread_mutex_init_value(&video->gpu_encoder_mutex);
+	da_free(video->gpu_encoders);
+
+	video->gpu_encoder_active = 0;
+	video->cur_texture = 0;
+}
+
 void obs_free_video_mix(struct obs_core_video_mix *video)
 {
 	if (obs && obs->video_rendering_mix == video)
 		obs->video_rendering_mix = NULL;
 
-	if (video->video) {
-		video_output_close(video->video);
-		video->video = NULL;
+	if (video->video)
+		obs_free_video_mix_resources(video, true);
 
-		obs_free_render_textures(video);
-
-		deque_free(&video->vframe_info_buffer);
-		deque_free(&video->vframe_info_buffer_gpu);
-
-		video->texture_rendered = false;
-		memset(video->textures_copied, 0, sizeof(video->textures_copied));
-		video->texture_converted = false;
-
-		pthread_mutex_destroy(&video->gpu_encoder_mutex);
-		pthread_mutex_init_value(&video->gpu_encoder_mutex);
-		da_free(video->gpu_encoders);
-
-		video->gpu_encoder_active = 0;
-		video->cur_texture = 0;
-	}
-
-	assert(video->retains_canvas_identity ==
-	       (video->kind == OBS_CORE_VIDEO_MIX_KIND_AUXILIARY));
-	assert(video->kind != OBS_CORE_VIDEO_MIX_KIND_AUXILIARY ||
-	       video->preserve_frame_rate);
-	if (video->retains_canvas_identity) {
+	assert(video->kind != OBS_CORE_VIDEO_MIX_KIND_AUXILIARY || video->preserve_frame_rate);
+	if (video->kind != OBS_CORE_VIDEO_MIX_KIND_ORDINARY) {
 		assert(video->canvas_ovi != NULL);
-		obs_video_info_release_auxiliary_mix_ref(video->canvas_ovi);
-		video->retains_canvas_identity = false;
+		obs_video_info_release_non_ordinary_mix_ref(video->canvas_ovi);
 	}
 	bfree(video);
 }
@@ -938,8 +963,7 @@ static void obs_free_video(bool full_clean)
 {
 	blog(LOG_INFO, "obs_free_video - full_clean: %d", full_clean);
 	if (!obs->video.graphics) {
-		blog(LOG_INFO,
-		     "obs_free_video - video is not initialized yet, skipping");
+		blog(LOG_INFO, "obs_free_video - video is not initialized yet, skipping");
 		return;
 	}
 
@@ -1001,6 +1025,8 @@ static void obs_free_video(bool full_clean)
 	if (full_clean) {
 		pthread_mutex_destroy(&obs->video.mixes_mutex);
 		pthread_mutex_init_value(&obs->video.mixes_mutex);
+		pthread_mutex_destroy(&obs->video.mix_cleanup_mutex);
+		pthread_mutex_init_value(&obs->video.mix_cleanup_mutex);
 	}
 
 	for (size_t i = 0; i < obs->video.ready_encoder_groups.num; i++) {
@@ -1018,7 +1044,7 @@ static void obs_free_video(bool full_clean)
 			struct obs_managed_video_info *managed =
 				(struct obs_managed_video_info *)obs->video.canvases.array[i];
 			assert(managed->scene_item_refs == 0);
-			assert(managed->auxiliary_mix_refs == 0);
+			assert(managed->non_ordinary_mix_refs == 0);
 			bfree(managed);
 			obs->video.canvases.array[i] = NULL;
 		}
@@ -1412,8 +1438,7 @@ static inline bool obs_init_hotkeys(void)
 	if (os_event_init(&hotkeys->stop_event, OS_EVENT_TYPE_MANUAL) != 0)
 		goto fail;
 	if (key_processing_enabled) {
-		if (pthread_create(&hotkeys->hotkey_thread, NULL,
-				   obs_hotkey_thread, NULL))
+		if (pthread_create(&hotkeys->hotkey_thread, NULL, obs_hotkey_thread, NULL))
 			goto fail;
 
 		hotkeys->strict_modifiers = true;
@@ -1478,11 +1503,9 @@ const struct obs_source_info audio_line_info = {
 
 extern void log_system_info(void);
 
-static bool obs_init(const char *locale, const char *module_config_path,
-		     profiler_name_store_t *store)
+static bool obs_init(const char *locale, const char *module_config_path, profiler_name_store_t *store)
 {
-	blog(LOG_INFO, "OBS API version %d.%d.%d", LIBOBS_API_MAJOR_VER,
-	     LIBOBS_API_MINOR_VER, LIBOBS_API_PATCH_VER);
+	blog(LOG_INFO, "OBS API version %d.%d.%d", LIBOBS_API_MAJOR_VER, LIBOBS_API_MINOR_VER, LIBOBS_API_PATCH_VER);
 
 	obs = bzalloc(sizeof(struct obs_core));
 
@@ -1491,6 +1514,7 @@ static bool obs_init(const char *locale, const char *module_config_path,
 	pthread_mutex_init_value(&obs->video.task_mutex);
 	pthread_mutex_init_value(&obs->video.encoder_group_mutex);
 	pthread_mutex_init_value(&obs->video.mixes_mutex);
+	pthread_mutex_init_value(&obs->video.mix_cleanup_mutex);
 	pthread_mutex_init_value(&obs->video.canvases_mutex);
 
 	obs->name_store_owned = !store;
@@ -1526,8 +1550,7 @@ static bool obs_init(const char *locale, const char *module_config_path,
 	obs_register_source(&audio_line_info);
 	add_default_module_paths();
 	obs->multiple_rendering = false;
-	obs->replay_buffer_rendering_mode =
-		OBS_RECORDING_REPLAY_BUFFER_RENDERING;
+	obs->replay_buffer_rendering_mode = OBS_RECORDING_REPLAY_BUFFER_RENDERING;
 	obs->video_rendering_mode = OBS_MAIN_VIDEO_RENDERING;
 	obs->audio_rendering_mode = OBS_MAIN_AUDIO_RENDERING;
 
@@ -1816,15 +1839,13 @@ int obs_reset_video(struct obs_video_info *ovi)
 int obs_deactivate_video_info()
 {
 	if (!obs) {
-		blog(LOG_ERROR,
-		     "[VIDEO_CANVAS] obs object is null, video reset is not possible");
+		blog(LOG_ERROR, "[VIDEO_CANVAS] obs object is null, video reset is not possible");
 		return OBS_VIDEO_FAIL;
 	}
 
 	/* don't allow changing of video settings if active. */
 	if (obs_video_active()) {
-		blog(LOG_ERROR,
-		     "[VIDEO_CANVAS] video is active, video reset is not possible");
+		blog(LOG_ERROR, "[VIDEO_CANVAS] video is active, video reset is not possible");
 		return OBS_VIDEO_CURRENTLY_ACTIVE;
 	}
 
@@ -1837,8 +1858,7 @@ int obs_deactivate_video_info()
 	return OBS_VIDEO_SUCCESS;
 }
 
-int obs_set_video_info(struct obs_video_info *canvas,
-		       struct obs_video_info *updated)
+int obs_set_video_info(struct obs_video_info *canvas, struct obs_video_info *updated)
 {
 	int ret = obs_deactivate_video_info();
 	if (ret != OBS_VIDEO_SUCCESS)
@@ -1876,8 +1896,7 @@ int obs_set_video_info(struct obs_video_info *canvas,
 
 	bool yuv = format_is_yuv(updated->output_format);
 	const char *yuv_format = get_video_colorspace_name(updated->colorspace);
-	const char *yuv_range =
-		get_video_range_name(updated->output_format, updated->range);
+	const char *yuv_range = get_video_range_name(updated->output_format, updated->range);
 
 	blog(LOG_INFO, "---------------------------------");
 	blog(LOG_INFO,
@@ -1888,10 +1907,8 @@ int obs_set_video_info(struct obs_video_info *canvas,
 	     "\tfps:               %d/%d\n"
 	     "\tformat:            %s\n"
 	     "\tYUV mode:          %s%s%s",
-	     canvas, updated->base_width, updated->base_height,
-	     updated->output_width, updated->output_height, scale_type_name,
-	     updated->fps_num, updated->fps_den,
-	     get_video_format_name(updated->output_format),
+	     canvas, updated->base_width, updated->base_height, updated->output_width, updated->output_height,
+	     scale_type_name, updated->fps_num, updated->fps_den, get_video_format_name(updated->output_format),
 	     yuv ? yuv_format : "None", yuv ? "/" : "", yuv ? yuv_range : "");
 
 	*canvas = *updated;
@@ -1935,8 +1952,7 @@ bool obs_reset_audio2(const struct obs_audio_info2 *oai)
 		max_buffering_ticks = 45;
 	}
 
-	max_buffering_ms = max_buffering_ticks * AUDIO_OUTPUT_FRAMES *
-			   SEC_TO_MSEC / (int)oai->samples_per_sec;
+	max_buffering_ms = max_buffering_ticks * AUDIO_OUTPUT_FRAMES * SEC_TO_MSEC / (int)oai->samples_per_sec;
 
 	ai.name = "Audio";
 	ai.samples_per_sec = oai->samples_per_sec;
@@ -1983,8 +1999,7 @@ bool obs_get_video_info_current(struct obs_video_info *ovi)
 	return true;
 }
 
-bool obs_get_video_info_scene_item(obs_sceneitem_t *item,
-				   struct obs_video_info *ovi)
+bool obs_get_video_info_scene_item(obs_sceneitem_t *item, struct obs_video_info *ovi)
 {
 	blog(LOG_INFO, "[VIDEO_CANVAS] video info requested for scene item");
 
@@ -2001,15 +2016,13 @@ bool obs_get_video_info_scene_item(obs_sceneitem_t *item,
 	return true;
 }
 
-bool obs_get_video_info_for_output(obs_output_t *output,
-				   struct obs_video_info *ovi, size_t index)
+bool obs_get_video_info_for_output(obs_output_t *output, struct obs_video_info *ovi, size_t index)
 {
 	blog(LOG_INFO, "[VIDEO_CANVAS] video info requested for output");
 	if (!output || !output->video_encoders[index])
 		return false;
 
-	return obs_get_video_info_for_encoder(output->video_encoders[index],
-					      ovi);
+	return obs_get_video_info_for_encoder(output->video_encoders[index], ovi);
 }
 
 bool obs_get_video_info_for_encoder(obs_encoder_t *encoder, struct obs_video_info *ovi)
@@ -2051,22 +2064,20 @@ int obs_remove_video_info(struct obs_video_info *ovi)
 	bool found = false;
 
 	/* Mark the video info as removing while holding canvases_mutex. Scene items
-	 * and auxiliary mixes acquire references under the same mutex, so no new
+	 * and non-ordinary mixes acquire references under the same mutex, so no new
 	 * reference can race with the checks below. */
 	pthread_mutex_lock(&obs->video.canvases_mutex);
 	for (size_t i = 0; i < obs->video.canvases.num; i++) {
 		if (obs->video.canvases.array[i] != ovi)
 			continue;
 
-		struct obs_managed_video_info *managed =
-			(struct obs_managed_video_info *)ovi;
+		struct obs_managed_video_info *managed = (struct obs_managed_video_info *)ovi;
 		found = true;
 		if (managed->removing) {
 			pthread_mutex_unlock(&obs->video.canvases_mutex);
 			return OBS_VIDEO_INVALID_PARAM;
 		}
-		if (managed->scene_item_refs != 0 ||
-		    managed->auxiliary_mix_refs != 0) {
+		if (managed->scene_item_refs != 0 || managed->non_ordinary_mix_refs != 0) {
 			pthread_mutex_unlock(&obs->video.canvases_mutex);
 			return OBS_VIDEO_INFO_IN_USE;
 		}
@@ -2083,8 +2094,7 @@ int obs_remove_video_info(struct obs_video_info *ovi)
 		pthread_mutex_lock(&obs->video.canvases_mutex);
 		for (size_t i = 0; i < obs->video.canvases.num; i++) {
 			if (obs->video.canvases.array[i] == ovi) {
-				struct obs_managed_video_info *managed =
-					(struct obs_managed_video_info *)ovi;
+				struct obs_managed_video_info *managed = (struct obs_managed_video_info *)ovi;
 				managed->removing = false;
 				break;
 			}
@@ -2105,8 +2115,8 @@ int obs_remove_video_info(struct obs_video_info *ovi)
 
 	ret = obs_init_video();
 	if (ret != OBS_VIDEO_SUCCESS) {
-		blog(LOG_ERROR, "Video info was removed, but the remaining video configuration failed to initialize: %d",
-		     ret);
+		blog(LOG_ERROR,
+		     "Video info was removed, but the remaining video configuration failed to initialize: %d", ret);
 		return OBS_VIDEO_REINITIALIZATION_FAILED;
 	}
 
@@ -2115,8 +2125,7 @@ int obs_remove_video_info(struct obs_video_info *ovi)
 
 struct obs_video_info *obs_create_video_info()
 {
-	struct obs_managed_video_info *managed =
-		bzalloc(sizeof(struct obs_managed_video_info));
+	struct obs_managed_video_info *managed = bzalloc(sizeof(struct obs_managed_video_info));
 	struct obs_video_info *ovi = &managed->ovi;
 	pthread_mutex_lock(&obs->video.canvases_mutex);
 	da_push_back(obs->video.canvases, &ovi);
@@ -2160,8 +2169,7 @@ bool obs_video_info_add_sceneitem_ref(struct obs_video_info *ovi)
 		if (obs->video.canvases.array[i] != ovi)
 			continue;
 
-		struct obs_managed_video_info *managed =
-			(struct obs_managed_video_info *)ovi;
+		struct obs_managed_video_info *managed = (struct obs_managed_video_info *)ovi;
 		if (!managed->removing) {
 			managed->scene_item_refs++;
 			retained = true;
@@ -2182,8 +2190,7 @@ void obs_video_info_release_sceneitem_ref(struct obs_video_info *ovi)
 		if (obs->video.canvases.array[i] != ovi)
 			continue;
 
-		struct obs_managed_video_info *managed =
-			(struct obs_managed_video_info *)ovi;
+		struct obs_managed_video_info *managed = (struct obs_managed_video_info *)ovi;
 		assert(managed->scene_item_refs != 0);
 		managed->scene_item_refs--;
 		break;
@@ -2191,7 +2198,7 @@ void obs_video_info_release_sceneitem_ref(struct obs_video_info *ovi)
 	pthread_mutex_unlock(&obs->video.canvases_mutex);
 }
 
-bool obs_video_info_add_auxiliary_mix_ref(struct obs_video_info *ovi)
+bool obs_video_info_add_non_ordinary_mix_ref(struct obs_video_info *ovi)
 {
 	if (!ovi || !obs)
 		return false;
@@ -2202,10 +2209,9 @@ bool obs_video_info_add_auxiliary_mix_ref(struct obs_video_info *ovi)
 		if (obs->video.canvases.array[i] != ovi)
 			continue;
 
-		struct obs_managed_video_info *managed =
-			(struct obs_managed_video_info *)ovi;
+		struct obs_managed_video_info *managed = (struct obs_managed_video_info *)ovi;
 		if (!managed->removing) {
-			managed->auxiliary_mix_refs++;
+			managed->non_ordinary_mix_refs++;
 			retained = true;
 		}
 		break;
@@ -2214,7 +2220,7 @@ bool obs_video_info_add_auxiliary_mix_ref(struct obs_video_info *ovi)
 	return retained;
 }
 
-void obs_video_info_release_auxiliary_mix_ref(struct obs_video_info *ovi)
+void obs_video_info_release_non_ordinary_mix_ref(struct obs_video_info *ovi)
 {
 	if (!ovi || !obs)
 		return;
@@ -2224,10 +2230,9 @@ void obs_video_info_release_auxiliary_mix_ref(struct obs_video_info *ovi)
 		if (obs->video.canvases.array[i] != ovi)
 			continue;
 
-		struct obs_managed_video_info *managed =
-			(struct obs_managed_video_info *)ovi;
-		assert(managed->auxiliary_mix_refs != 0);
-		managed->auxiliary_mix_refs--;
+		struct obs_managed_video_info *managed = (struct obs_managed_video_info *)ovi;
+		assert(managed->non_ordinary_mix_refs != 0);
+		managed->non_ordinary_mix_refs--;
 		break;
 	}
 	pthread_mutex_unlock(&obs->video.canvases_mutex);
@@ -2247,7 +2252,7 @@ bool obs_get_video_info_by_index(size_t index, struct obs_video_info *ovi)
 	return true;
 }
 
-struct obs_video_info * obs_get_video_info_by_index2(size_t index)
+struct obs_video_info *obs_get_video_info_by_index2(size_t index)
 {
 	blog(LOG_INFO, "[VIDEO_CANVAS] obs_get_video_info_by_index2 - %zu", index);
 
@@ -2256,7 +2261,6 @@ struct obs_video_info * obs_get_video_info_by_index2(size_t index)
 
 	return obs->video.canvases.array[index];
 }
-
 
 float obs_get_video_sdr_white_level(void)
 {
@@ -2423,8 +2427,7 @@ video_t *obs_get_video(void)
 	return obs->data.main_canvas->mix->video;
 }
 
-static bool handle_videos_callback(obs_scene_t *scene, obs_sceneitem_t *item,
-				   void *data)
+static bool handle_videos_callback(obs_scene_t *scene, obs_sceneitem_t *item, void *data)
 {
 	UNUSED_PARAMETER(scene);
 	bool backstage = (bool)data;
@@ -2445,8 +2448,7 @@ static bool handle_videos_callback(obs_scene_t *scene, obs_sceneitem_t *item,
 		source->on_backstage = false;
 
 		obs_data_t *settings = obs_source_get_settings(source);
-		const bool restart_on_activate =
-			obs_data_get_bool(settings, "restart_on_activate");
+		const bool restart_on_activate = obs_data_get_bool(settings, "restart_on_activate");
 		if (restart_on_activate) {
 			obs_source_media_restart(source);
 		}
@@ -2458,18 +2460,16 @@ static bool handle_videos_callback(obs_scene_t *scene, obs_sceneitem_t *item,
 
 void obs_activate_scene_on_backstage(obs_source_t *source)
 {
-	blog(LOG_INFO, "obs_activate_scene_on_backstage - 0x%" PRIXPTR " - %s",
-	     (uintptr_t)source, obs_source_get_name(source));
+	blog(LOG_INFO, "obs_activate_scene_on_backstage - 0x%" PRIXPTR " - %s", (uintptr_t)source,
+	     obs_source_get_name(source));
 
 	if (!source) {
-		blog(LOG_WARNING,
-		     "obs_activate_scene_on_backstage - source is NULL");
+		blog(LOG_WARNING, "obs_activate_scene_on_backstage - source is NULL");
 		return;
 	}
 
 	if (obs_source_get_type(source) != OBS_SOURCE_TYPE_SCENE) {
-		blog(LOG_WARNING,
-		     "obs_activate_scene_on_backstage - trying to add not a scene");
+		blog(LOG_WARNING, "obs_activate_scene_on_backstage - trying to add not a scene");
 		return;
 	}
 
@@ -2479,8 +2479,7 @@ void obs_activate_scene_on_backstage(obs_source_t *source)
 	}
 }
 
-static void handle_transition_sources_callback(obs_source_t *parent,
-					       obs_source_t *child, void *data)
+static void handle_transition_sources_callback(obs_source_t *parent, obs_source_t *child, void *data)
 {
 	UNUSED_PARAMETER(parent);
 	bool backstage = (bool)data;
@@ -2498,14 +2497,13 @@ static void handle_transition_sources_callback(obs_source_t *parent,
 
 void obs_activate_videos_on_backstage(obs_source_t *source)
 {
-	blog(LOG_INFO, "obs_activate_videos_on_backstage - 0x%" PRIXPTR " - %s",
-	     (uintptr_t)source, obs_source_get_name(source));
+	blog(LOG_INFO, "obs_activate_videos_on_backstage - 0x%" PRIXPTR " - %s", (uintptr_t)source,
+	     obs_source_get_name(source));
 
 	if (obs_source_get_type(source) == OBS_SOURCE_TYPE_TRANSITION) {
 		obs_source_activate(source, MAIN_VIEW);
 
-		obs_source_enum_active_tree(
-			source, handle_transition_sources_callback, (void *)1);
+		obs_source_enum_active_tree(source, handle_transition_sources_callback, (void *)1);
 	} else if (obs_source_get_type(source) == OBS_SOURCE_TYPE_SCENE) {
 		source->on_backstage = true;
 		obs_scene_t *scene = obs_scene_from_source(source);
@@ -2515,18 +2513,15 @@ void obs_activate_videos_on_backstage(obs_source_t *source)
 
 void obs_deactivate_scene_on_backstage(obs_source_t *source)
 {
-	blog(LOG_INFO,
-	     "obs_deactivate_scene_on_backstage - 0x%" PRIXPTR " - %s",
-	     (uintptr_t)source, obs_source_get_name(source));
+	blog(LOG_INFO, "obs_deactivate_scene_on_backstage - 0x%" PRIXPTR " - %s", (uintptr_t)source,
+	     obs_source_get_name(source));
 	if (!source) {
-		blog(LOG_WARNING,
-		     "obs_deactivate_scene_on_backstage - source is NULL");
+		blog(LOG_WARNING, "obs_deactivate_scene_on_backstage - source is NULL");
 		return;
 	}
 
 	if (obs_source_get_type(source) != OBS_SOURCE_TYPE_SCENE) {
-		blog(LOG_WARNING,
-		     "obs_deactivate_scene_on_backstage - trying to remove not a scene");
+		blog(LOG_WARNING, "obs_deactivate_scene_on_backstage - trying to remove not a scene");
 		return;
 	}
 
@@ -2536,14 +2531,12 @@ void obs_deactivate_scene_on_backstage(obs_source_t *source)
 
 void obs_deactivate_videos_on_backstage(obs_source_t *source)
 {
-	blog(LOG_INFO,
-	     "obs_deactivate_videos_on_backstage - 0x%" PRIXPTR " - %s",
-	     (uintptr_t)source, obs_source_get_name(source));
+	blog(LOG_INFO, "obs_deactivate_videos_on_backstage - 0x%" PRIXPTR " - %s", (uintptr_t)source,
+	     obs_source_get_name(source));
 
 	if (obs_source_get_type(source) == OBS_SOURCE_TYPE_TRANSITION) {
 		obs_source_deactivate(source, MAIN_VIEW);
-		obs_source_enum_active_tree(
-			source, handle_transition_sources_callback, (void *)0);
+		obs_source_enum_active_tree(source, handle_transition_sources_callback, (void *)0);
 
 	} else if (obs_source_get_type(source) == OBS_SOURCE_TYPE_SCENE) {
 		obs_scene_t *scene = obs_scene_from_source(source);
@@ -2642,8 +2635,7 @@ bool obs_scene_is_present(obs_scene_t *checking_scene)
 	if (checking_scene == NULL)
 		return false;
 
-	if (((obs_source_t *)checking_scene)->info.type !=
-	    OBS_SOURCE_TYPE_SCENE)
+	if (((obs_source_t *)checking_scene)->info.type != OBS_SOURCE_TYPE_SCENE)
 		return false;
 
 	obs_enum_scenes(scene_ref_enum_callback, &checking_scene);
@@ -2988,11 +2980,8 @@ static void obs_render_canvas_texture_internal(obs_canvas_t *canvas, enum gs_ble
 	gs_enable_framebuffer_srgb(previous);
 }
 
-static void obs_render_texture_internal(enum gs_blend_type src_c,
-					enum gs_blend_type dest_c,
-					enum gs_blend_type src_a,
-					enum gs_blend_type dest_a,
-					struct obs_core_video_mix *video)
+static void obs_render_texture_internal(enum gs_blend_type src_c, enum gs_blend_type dest_c, enum gs_blend_type src_a,
+					enum gs_blend_type dest_a, struct obs_core_video_mix *video)
 {
 	gs_texture_t *tex;
 	gs_effect_t *effect;
@@ -3048,7 +3037,8 @@ void obs_render_main_texture(void)
 
 void obs_render_texture(struct obs_video_info *ovi, enum obs_video_rendering_mode mode)
 {
-	obs_render_texture_internal(GS_BLEND_ONE, GS_BLEND_INVSRCALPHA, GS_BLEND_ONE, GS_BLEND_INVSRCALPHA, obs_video_mix_get(ovi, mode));
+	obs_render_texture_internal(GS_BLEND_ONE, GS_BLEND_INVSRCALPHA, GS_BLEND_ONE, GS_BLEND_INVSRCALPHA,
+				    obs_video_mix_get(ovi, mode));
 }
 
 void obs_render_main_texture_src_color_only(void)
@@ -3181,8 +3171,7 @@ void obs_set_video_render_context(struct obs_core_video_mix *mix)
 	obs->video_rendering_mix = mix;
 }
 
-void obs_set_replay_buffer_rendering_mode(
-	enum obs_replay_buffer_rendering_mode mode)
+void obs_set_replay_buffer_rendering_mode(enum obs_replay_buffer_rendering_mode mode)
 {
 	if (!obs)
 		return;
@@ -4029,19 +4018,28 @@ uint32_t obs_get_lagged_frames(void)
 	return obs->video.lagged_frames;
 }
 
-struct obs_core_video_mix *get_mix_for_video(video_t *v)
+struct obs_core_video_mix *get_mix_for_video_locked(video_t *v)
 {
-	struct obs_core_video_mix *result = NULL;
+	if (!obs || !v)
+		return NULL;
 
-	pthread_mutex_lock(&obs->video.mixes_mutex);
 	for (size_t i = 0, num = obs->video.mixes.num; i < num; i++) {
 		struct obs_core_video_mix *mix = obs->video.mixes.array[i];
 
-		if (v == mix->video) {
-			result = mix;
-			break;
-		}
+		if (v == mix->video)
+			return mix;
 	}
+
+	return NULL;
+}
+
+struct obs_core_video_mix *get_mix_for_video(video_t *v)
+{
+	if (!obs || !v)
+		return NULL;
+
+	pthread_mutex_lock(&obs->video.mixes_mutex);
+	struct obs_core_video_mix *result = get_mix_for_video_locked(v);
 	pthread_mutex_unlock(&obs->video.mixes_mutex);
 
 	return result;
@@ -4130,8 +4128,7 @@ extern void free_gpu_encoding(struct obs_core_video_mix *video);
 
 bool start_gpu_encode(obs_encoder_t *encoder)
 {
-	blog(LOG_INFO, "start_gpu_encode '%s' (%s) (%p)",
-	     obs_encoder_get_name(encoder), obs_encoder_get_id(encoder),
+	blog(LOG_INFO, "start_gpu_encode '%s' (%s) (%p)", obs_encoder_get_name(encoder), obs_encoder_get_id(encoder),
 	     encoder);
 
 	struct obs_core_video_mix *video = get_mix_for_video(encoder->media);
@@ -4154,10 +4151,8 @@ bool start_gpu_encode(obs_encoder_t *encoder)
 	if (success)
 		da_push_back(video->gpu_encoders, &encoder);
 	else {
-		blog(LOG_ERROR,
-		     "start_gpu_encode - init_gpu_encoding failed! '%s' (%s) (%p)",
-		     obs_encoder_get_name(encoder), obs_encoder_get_id(encoder),
-		     encoder);
+		blog(LOG_ERROR, "start_gpu_encode - init_gpu_encoding failed! '%s' (%s) (%p)",
+		     obs_encoder_get_name(encoder), obs_encoder_get_id(encoder), encoder);
 		free_gpu_encoding(video);
 	}
 
@@ -4174,8 +4169,7 @@ bool start_gpu_encode(obs_encoder_t *encoder)
 
 void stop_gpu_encode(obs_encoder_t *encoder)
 {
-	blog(LOG_INFO, "stop_gpu_encode '%s' (%s) (%p)",
-	     obs_encoder_get_name(encoder), obs_encoder_get_id(encoder),
+	blog(LOG_INFO, "stop_gpu_encode '%s' (%s) (%p)", obs_encoder_get_name(encoder), obs_encoder_get_id(encoder),
 	     encoder);
 	struct obs_core_video_mix *video = get_mix_for_video(encoder->media);
 
@@ -4193,10 +4187,8 @@ void stop_gpu_encode(obs_encoder_t *encoder)
 
 	obs_enter_graphics();
 	if (video->gpu_want_destroy_thread) {
-		blog(LOG_INFO,
-		     "stop_gpu_encode - gpu_want_destroy_thread: 1 '%s' (%s) (%p)",
-		     obs_encoder_get_name(encoder), obs_encoder_get_id(encoder),
-		     encoder);
+		blog(LOG_INFO, "stop_gpu_encode - gpu_want_destroy_thread: 1 '%s' (%s) (%p)",
+		     obs_encoder_get_name(encoder), obs_encoder_get_id(encoder), encoder);
 		stop_gpu_encoding_thread(video);
 		free_gpu_encoding(video);
 	}

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -32,9 +32,15 @@ const bool key_processing_enabled = false;
 struct obs_managed_video_info {
 	struct obs_video_info ovi;
 	size_t scene_item_refs;
-	/* Number of non-ordinary mixes retaining this video info. */
+	/* Number of non-ordinary mixes retaining this registered video info. */
 	size_t non_ordinary_mix_refs;
 	bool removing;
+};
+
+enum video_info_retain_result {
+	VIDEO_INFO_RETAIN_UNREGISTERED,
+	VIDEO_INFO_RETAINED,
+	VIDEO_INFO_RETAIN_REMOVING,
 };
 
 extern void add_default_module_paths(void);
@@ -42,6 +48,8 @@ extern char *find_libobs_data_file(const char *file);
 static void obs_free_graphics(void);
 static void obs_free_render_textures(struct obs_core_video_mix *video);
 static void obs_free_video_mix_resources(struct obs_core_video_mix *video, bool mutex_initialized);
+static enum video_info_retain_result obs_video_info_retain_non_ordinary_mix_ref(struct obs_video_info *ovi);
+static bool obs_video_info_release_non_ordinary_mix_ref(struct obs_video_info *ovi);
 
 static inline void make_video_info(struct video_output_info *vi, const struct obs_video_info *ovi)
 {
@@ -708,12 +716,18 @@ struct obs_core_video_mix *obs_create_video_mix_internal(const struct obs_video_
 		if (preserve_frame_rate || render_info != canvas_ovi)
 			return NULL;
 		break;
-	case OBS_CORE_VIDEO_MIX_KIND_ENCODER_ONLY:
-		if (!obs_video_info_add_non_ordinary_mix_ref(canvas_ovi))
+	case OBS_CORE_VIDEO_MIX_KIND_ENCODER_ONLY: {
+		/* Encoder-only mixes can inherit an unregistered, canvas-owned
+		 * identity from their source mix. A registered identity must still be
+		 * retained so removal cannot race with mix creation. */
+		enum video_info_retain_result result = obs_video_info_retain_non_ordinary_mix_ref(canvas_ovi);
+		if (result == VIDEO_INFO_RETAIN_REMOVING)
 			return NULL;
 		break;
+	}
 	case OBS_CORE_VIDEO_MIX_KIND_AUXILIARY:
-		if (!preserve_frame_rate || !obs_video_info_add_non_ordinary_mix_ref(canvas_ovi))
+		if (!preserve_frame_rate ||
+		    obs_video_info_retain_non_ordinary_mix_ref(canvas_ovi) != VIDEO_INFO_RETAINED)
 			return NULL;
 		break;
 	default:
@@ -954,7 +968,12 @@ void obs_free_video_mix(struct obs_core_video_mix *video)
 	assert(video->kind != OBS_CORE_VIDEO_MIX_KIND_AUXILIARY || video->preserve_frame_rate);
 	if (video->kind != OBS_CORE_VIDEO_MIX_KIND_ORDINARY) {
 		assert(video->canvas_ovi != NULL);
-		obs_video_info_release_non_ordinary_mix_ref(video->canvas_ovi);
+		/* Registered identities remain discoverable while retained. An
+		 * encoder-only canvas-owned identity remains alive and unregistered
+		 * until its source mix releases the encoder during teardown. */
+		const bool released = obs_video_info_release_non_ordinary_mix_ref(video->canvas_ovi);
+		assert(video->kind != OBS_CORE_VIDEO_MIX_KIND_AUXILIARY || released);
+		UNUSED_PARAMETER(released);
 	}
 	bfree(video);
 }
@@ -2198,12 +2217,12 @@ void obs_video_info_release_sceneitem_ref(struct obs_video_info *ovi)
 	pthread_mutex_unlock(&obs->video.canvases_mutex);
 }
 
-bool obs_video_info_add_non_ordinary_mix_ref(struct obs_video_info *ovi)
+static enum video_info_retain_result obs_video_info_retain_non_ordinary_mix_ref(struct obs_video_info *ovi)
 {
 	if (!ovi || !obs)
-		return false;
+		return VIDEO_INFO_RETAIN_REMOVING;
 
-	bool retained = false;
+	enum video_info_retain_result result = VIDEO_INFO_RETAIN_UNREGISTERED;
 	pthread_mutex_lock(&obs->video.canvases_mutex);
 	for (size_t i = 0; i < obs->video.canvases.num; i++) {
 		if (obs->video.canvases.array[i] != ovi)
@@ -2212,19 +2231,22 @@ bool obs_video_info_add_non_ordinary_mix_ref(struct obs_video_info *ovi)
 		struct obs_managed_video_info *managed = (struct obs_managed_video_info *)ovi;
 		if (!managed->removing) {
 			managed->non_ordinary_mix_refs++;
-			retained = true;
+			result = VIDEO_INFO_RETAINED;
+		} else {
+			result = VIDEO_INFO_RETAIN_REMOVING;
 		}
 		break;
 	}
 	pthread_mutex_unlock(&obs->video.canvases_mutex);
-	return retained;
+	return result;
 }
 
-void obs_video_info_release_non_ordinary_mix_ref(struct obs_video_info *ovi)
+static bool obs_video_info_release_non_ordinary_mix_ref(struct obs_video_info *ovi)
 {
 	if (!ovi || !obs)
-		return;
+		return false;
 
+	bool released = false;
 	pthread_mutex_lock(&obs->video.canvases_mutex);
 	for (size_t i = 0; i < obs->video.canvases.num; i++) {
 		if (obs->video.canvases.array[i] != ovi)
@@ -2233,9 +2255,11 @@ void obs_video_info_release_non_ordinary_mix_ref(struct obs_video_info *ovi)
 		struct obs_managed_video_info *managed = (struct obs_managed_video_info *)ovi;
 		assert(managed->non_ordinary_mix_refs != 0);
 		managed->non_ordinary_mix_refs--;
+		released = true;
 		break;
 	}
 	pthread_mutex_unlock(&obs->video.canvases_mutex);
+	return released;
 }
 
 size_t obs_get_video_info_count()

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -32,6 +32,8 @@ const bool key_processing_enabled = false;
 struct obs_managed_video_info {
 	struct obs_video_info ovi;
 	size_t scene_item_refs;
+	/* Keeps the registered identity alive while auxiliary mixes borrow it. */
+	size_t auxiliary_mix_refs;
 	bool removing;
 };
 
@@ -644,14 +646,16 @@ static void sync_mix_fps_with_main_canvas(struct obs_core_video_mix *video)
 	pthread_mutex_unlock(&obs->video.mixes_mutex);
 }
 
-static int obs_init_video_mix(struct obs_video_info *ovi, struct obs_core_video_mix *video)
+static int obs_init_video_mix(struct obs_video_info *ovi,
+			      struct obs_core_video_mix *video)
 {
 	struct video_output_info vi;
 
 	pthread_mutex_init_value(&video->gpu_encoder_mutex);
 
 	video->ovi = *ovi;
-	sync_mix_fps_with_main_canvas(video);
+	if (!video->preserve_frame_rate)
+		sync_mix_fps_with_main_canvas(video);
 	make_video_info(&vi, &video->ovi);
 
 	video->gpu_conversion = ovi->gpu_conversion;
@@ -687,16 +691,24 @@ static int obs_init_video_mix(struct obs_video_info *ovi, struct obs_core_video_
 	return OBS_VIDEO_SUCCESS;
 }
 
-struct obs_core_video_mix *obs_create_video_mix(struct obs_video_info *ovi)
+struct obs_core_video_mix *
+obs_create_video_mix_with_frame_rate(struct obs_video_info *ovi,
+				     bool preserve_frame_rate)
 {
 	struct obs_core_video_mix *video =
 		bzalloc(sizeof(struct obs_core_video_mix));
 	video->canvas_ovi = ovi;
+	video->preserve_frame_rate = preserve_frame_rate;
 	if (obs_init_video_mix(ovi, video) != OBS_VIDEO_SUCCESS) {
 		bfree(video);
 		video = NULL;
 	}
 	return video;
+}
+
+struct obs_core_video_mix *obs_create_video_mix(struct obs_video_info *ovi)
+{
+	return obs_create_video_mix_with_frame_rate(ovi, false);
 }
 
 static bool restore_canvases(void)
@@ -909,6 +921,11 @@ void obs_free_video_mix(struct obs_core_video_mix *video)
 		video->gpu_encoder_active = 0;
 		video->cur_texture = 0;
 	}
+
+	if (video->retains_canvas_identity) {
+		obs_video_info_release_auxiliary_mix_ref(video->canvas_ovi);
+		video->retains_canvas_identity = false;
+	}
 	bfree(video);
 }
 
@@ -993,7 +1010,10 @@ static void obs_free_video(bool full_clean)
 		pthread_mutex_lock(&obs->video.canvases_mutex);
 		size_t num = obs->video.canvases.num;
 		for (size_t i = 0; i < num; i++) {
-			assert(((struct obs_managed_video_info *)obs->video.canvases.array[i])->scene_item_refs == 0);
+			struct obs_managed_video_info *managed =
+				(struct obs_managed_video_info *)obs->video.canvases.array[i];
+			assert(managed->scene_item_refs == 0);
+			assert(managed->auxiliary_mix_refs == 0);
 			bfree(obs->video.canvases.array[i]);
 			obs->video.canvases.array[i] = NULL;
 		}
@@ -2025,9 +2045,9 @@ int obs_remove_video_info(struct obs_video_info *ovi)
 
 	bool found = false;
 
-	/* Mark the video info as removing before deactivating video.  Canvas
-	 * assignment takes the same mutex, so no new scene-item reference can
-	 * race with the reference check below. */
+	/* Mark the video info as removing before deactivating video. Canvas
+	 * assignment and auxiliary identity retention take the same mutex, so no
+	 * new owner can race with the reference checks below. */
 	pthread_mutex_lock(&obs->video.canvases_mutex);
 	for (size_t i = 0; i < obs->video.canvases.num; i++) {
 		if (obs->video.canvases.array[i] != ovi)
@@ -2040,7 +2060,8 @@ int obs_remove_video_info(struct obs_video_info *ovi)
 			pthread_mutex_unlock(&obs->video.canvases_mutex);
 			return OBS_VIDEO_INVALID_PARAM;
 		}
-		if (managed->scene_item_refs != 0) {
+		if (managed->scene_item_refs != 0 ||
+		    managed->auxiliary_mix_refs != 0) {
 			pthread_mutex_unlock(&obs->video.canvases_mutex);
 			return OBS_VIDEO_INFO_IN_USE;
 		}
@@ -2160,6 +2181,48 @@ void obs_video_info_release_sceneitem_ref(struct obs_video_info *ovi)
 			(struct obs_managed_video_info *)ovi;
 		assert(managed->scene_item_refs != 0);
 		managed->scene_item_refs--;
+		break;
+	}
+	pthread_mutex_unlock(&obs->video.canvases_mutex);
+}
+
+bool obs_video_info_add_auxiliary_mix_ref(struct obs_video_info *ovi)
+{
+	if (!ovi || !obs)
+		return false;
+
+	bool retained = false;
+	pthread_mutex_lock(&obs->video.canvases_mutex);
+	for (size_t i = 0; i < obs->video.canvases.num; i++) {
+		if (obs->video.canvases.array[i] != ovi)
+			continue;
+
+		struct obs_managed_video_info *managed =
+			(struct obs_managed_video_info *)ovi;
+		if (!managed->removing) {
+			managed->auxiliary_mix_refs++;
+			retained = true;
+		}
+		break;
+	}
+	pthread_mutex_unlock(&obs->video.canvases_mutex);
+	return retained;
+}
+
+void obs_video_info_release_auxiliary_mix_ref(struct obs_video_info *ovi)
+{
+	if (!ovi || !obs)
+		return;
+
+	pthread_mutex_lock(&obs->video.canvases_mutex);
+	for (size_t i = 0; i < obs->video.canvases.num; i++) {
+		if (obs->video.canvases.array[i] != ovi)
+			continue;
+
+		struct obs_managed_video_info *managed =
+			(struct obs_managed_video_info *)ovi;
+		assert(managed->auxiliary_mix_refs != 0);
+		managed->auxiliary_mix_refs--;
 		break;
 	}
 	pthread_mutex_unlock(&obs->video.canvases_mutex);
@@ -3053,7 +3116,10 @@ obs_core_video_mix_t *obs_video_mix_get(struct obs_video_info *ovi, enum obs_vid
 	// As this canvas is unused, we can safely skip it.
 	for (size_t i = 1, num = obs->video.mixes.num; i < num; i++) {
 		struct obs_core_video_mix *mix = obs->video.mixes.array[i];
-		if (!mix || mix->encoder_only_mix)
+		/* Auxiliary mixes deliberately share a canvas identity with a normal
+		 * mix. Their creator receives the exact handle, while discovery must
+		 * continue to resolve the application's normal mix. */
+		if (!mix || mix->encoder_only_mix || mix->auxiliary_mix)
 			continue;
 		if ((mix->canvas_ovi == ovi || ovi == NULL) && mix->rendering_mode == mode) {
 			result = mix;

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -1123,6 +1123,42 @@ EXPORT video_t *obs_record_view_add(obs_view_t *view,
 /** Adds a view to the main render loop, with custom video settings */
 EXPORT video_t *obs_view_add2(obs_view_t *view, struct obs_video_info *ovi);
 
+/**
+ * Adds an auxiliary mix to the main render loop.
+ *
+ * Auxiliary mixes render the supplied view using a private copy of
+ * @p render_info, while using the registered canvas identity associated with
+ * @p identity_source_mix for scene membership and canvas-aware audio routing.
+ * This allows a caller to test candidate render settings without registering
+ * another application canvas or changing the identified canvas settings. In
+ * particular, the auxiliary mix and any encoder-only rescale mixes derived
+ * from it preserve the FPS supplied in @p render_info rather than inheriting
+ * the main canvas FPS.
+ *
+ * The @p render_info structure is copied synchronously; the caller may modify
+ * or release the structure after this function returns. The identity source
+ * must be a published, attached ordinary mix (neither auxiliary nor
+ * encoder-only) backed by a registered canvas. Auxiliary mixes are
+ * intentionally excluded from obs_video_mix_get() and
+ * obs_view_enum_video_info(); use the returned handle directly. The auxiliary
+ * mix inherits the identity source's rendering mode; callers must therefore
+ * select the ordinary identity source appropriate for the render pass they
+ * intend to exercise.
+ *
+ * The returned handle remains owned by libobs. Stop every encoder and output
+ * using the auxiliary mix before calling obs_view_remove(), and call
+ * obs_view_remove() before obs_view_destroy(). Removal releases the mix and its
+ * retained canvas identity asynchronously on the video thread. The identified
+ * canvas cannot be removed while that retention is active.
+ *
+ * @return The newly created auxiliary mix, or NULL if validation or creation
+ *         failed.
+ */
+EXPORT obs_core_video_mix_t *
+obs_view_add_auxiliary_mix(obs_view_t *view,
+			   const struct obs_video_info *render_info,
+			   obs_core_video_mix_t *identity_source_mix);
+
 /** Removes a view from the main render loop */
 EXPORT void obs_view_remove(obs_view_t *view);
 

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -955,12 +955,12 @@ EXPORT struct obs_video_info *obs_get_audio_rendering_canvas(void);
 EXPORT void obs_set_audio_rendering_canvas(struct obs_video_info *ovi);
 
 /**
- * Sets the active video mix for the current render pass.
+ * Sets the video mix used for rendering.
  *
- * The mix is borrowed and is not retained. It must remain valid for the
- * duration of the render pass. Pass NULL to clear the active context.
+ * No reference is added to @p mix. It must remain valid until another mix is
+ * set or the current mix is cleared by passing NULL.
  *
- * @param  mix  Active mix, or NULL to clear the context.
+ * @param  mix  Video mix to use, or NULL to clear the current mix.
  */
 EXPORT void obs_set_video_render_context(obs_core_video_mix_t *mix);
 
@@ -1131,43 +1131,30 @@ EXPORT video_t *obs_record_view_add(obs_view_t *view,
 EXPORT video_t *obs_view_add2(obs_view_t *view, struct obs_video_info *ovi);
 
 /**
- * Adds an auxiliary mix to the main render loop.
+ * Adds an auxiliary video mix to the main render loop.
  *
- * Auxiliary mixes render the supplied view using a private copy of
- * @p render_info, while using the registered canvas identity associated with
- * @p identity_source_mix for scene membership and canvas-aware audio routing.
- * This allows a caller to test candidate render settings without registering
- * another application canvas or changing the identified canvas settings. In
- * particular, the auxiliary mix and any encoder-only rescale mixes derived
- * from it preserve the FPS supplied in @p render_info rather than inheriting
- * the main canvas FPS.
+ * The mix renders @p view using a copy of @p render_info. It uses the
+ * registered video info and rendering mode from @p identity_source_mix for
+ * canvas-specific scene filtering and audio routing. Encoder scaling also
+ * preserves the frame rate specified by @p render_info.
  *
- * The @p render_info structure is copied synchronously; the caller may modify
- * or release the structure after this function returns. The identity source
- * must be a published, attached ordinary mix (neither auxiliary nor
- * encoder-only) backed by a registered canvas. Auxiliary mixes are
- * intentionally excluded from obs_video_mix_get() and
- * obs_view_enum_video_info(); use the returned handle directly. The auxiliary
- * mix inherits the identity source's rendering mode; callers must therefore
- * select the ordinary identity source appropriate for the render pass they
- * intend to exercise.
+ * @p identity_source_mix must be a valid mix returned by obs_video_mix_get()
+ * whose view remains in the main render loop. Auxiliary mixes are not returned
+ * by obs_video_mix_get() or represented in obs_view_enum_video_info(); use the
+ * handle returned by this function directly.
  *
- * The returned handle remains owned by libobs. Stop every encoder and output
- * using the auxiliary mix before calling obs_view_remove(), and call
- * obs_view_remove() before obs_view_destroy(). Removal releases the mix and its
- * retained canvas identity asynchronously on the video thread. The identified
- * canvas cannot be removed while that retention is active.
+ * libobs owns the returned mix. Keep @p view alive while it is in use.
+ * obs_view_remove() removes every mix associated with @p view, so stop all
+ * corresponding outputs and encoders before calling it. Do not use the handle
+ * afterward, and call obs_view_remove() before obs_view_destroy(). Cleanup
+ * completes asynchronously; the source video info remains in use until the
+ * video thread finishes cleanup.
  *
- * @param  view                 Non-NULL view whose sources the auxiliary mix
- *                              renders. It must remain alive until the mix is
- *                              removed with obs_view_remove().
- * @param  render_info          Non-NULL private render settings copied into
- *                              the auxiliary mix.
- * @param  identity_source_mix  Non-NULL published ordinary mix whose
- *                              registered canvas identity and rendering mode
- *                              are borrowed.
- * @return                      The newly created auxiliary mix, or NULL if
- *                              validation or creation failed.
+ * @param  view                 Non-NULL view to render.
+ * @param  render_info          Non-NULL video settings, copied by value.
+ * @param  identity_source_mix  Non-NULL source mix returned by
+ *                              obs_video_mix_get().
+ * @return                      The new auxiliary mix, or NULL on failure.
  */
 EXPORT obs_core_video_mix_t *
 obs_view_add_auxiliary_mix(obs_view_t *view,
@@ -2532,41 +2519,42 @@ EXPORT void obs_encoder_set_name(obs_encoder_t *encoder, const char *name);
 EXPORT const char *obs_encoder_get_name(const obs_encoder_t *encoder);
 
 /**
- * Binds an encoder to a currently published video mix.
+ * Sets the video mix to be used with an encoder.
  *
- * The mix is borrowed and remains owned by libobs. Binding it does not extend
- * its lifetime. For a video encoder, the encoder must be inactive and not yet
- * initialized. A NULL or stale mix, an invalid encoder, or an active or
- * initialized video encoder causes the request to be logged and ignored.
+ * @p video must be a valid mix owned by libobs. No reference is added, so the
+ * mix must remain valid while the encoder uses it. A video encoder must be
+ * inactive and not yet initialized. For an audio encoder, the mix selects the
+ * registered video info used for canvas-specific audio rendering. Invalid
+ * arguments or encoder state trigger a warning and leave the encoder unchanged.
  *
- * @param  encoder  Encoder to bind. Audio encoders use the mix identity for
- *                  canvas-aware audio routing.
- * @param  video    Published video mix to bind.
+ * @param  encoder  Encoder to update.
+ * @param  video    Non-NULL video mix to use.
  */
 EXPORT void obs_encoder_set_video_mix(obs_encoder_t *encoder,
 				      struct obs_core_video_mix *video);
 
 /**
- * Returns the video output owned by a video mix.
+ * Returns the video output context used by a video mix.
  *
- * The returned pointer is borrowed and remains valid only while @p mix is
- * valid. No reference or ownership is transferred.
+ * The returned pointer is owned by libobs and remains valid only while
+ * @p mix remains valid.
  *
  * @param  mix  Video mix to inspect, or NULL.
- * @return      The mix's video output, or NULL when @p mix is NULL.
+ * @return      Video output context, or NULL when @p mix is NULL.
  */
 EXPORT video_t *obs_video_mix_get_video(struct obs_core_video_mix *mix);
 
 /**
- * Finds a published ordinary video mix by canvas identity and rendering mode.
+ * Finds a non-main video mix by registered video info and rendering mode.
  *
- * Auxiliary and encoder-only mixes are excluded from discovery. A NULL @p ovi
- * matches any canvas identity. The returned handle is borrowed, transfers no
- * ownership, and remains valid only while the mix stays published.
+ * Auxiliary mixes and mixes created internally for encoder scaling are not
+ * returned. A NULL @p ovi matches any registered video info. The returned mix
+ * is owned by libobs and is not reference-counted; do not retain it after its
+ * view or video configuration is removed or reset.
  *
- * @param  ovi   Registered canvas identity to match, or NULL as a wildcard.
- * @param  mode  Rendering mode to match.
- * @return       The first matching ordinary mix, or NULL when no match exists.
+ * @param  ovi   Registered video info pointer to match, or NULL.
+ * @param  mode  Video rendering mode to match.
+ * @return       First matching video mix, or NULL if none is found.
  */
 EXPORT obs_core_video_mix_t *
 obs_video_mix_get(struct obs_video_info *ovi,

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -954,7 +954,14 @@ EXPORT enum obs_audio_rendering_mode obs_get_audio_rendering_mode(void);
 EXPORT struct obs_video_info *obs_get_audio_rendering_canvas(void);
 EXPORT void obs_set_audio_rendering_canvas(struct obs_video_info *ovi);
 
-/** Sets the active video render context for the current render pass. */
+/**
+ * Sets the active video mix for the current render pass.
+ *
+ * The mix is borrowed and is not retained. It must remain valid for the
+ * duration of the render pass. Pass NULL to clear the active context.
+ *
+ * @param  mix  Active mix, or NULL to clear the context.
+ */
 EXPORT void obs_set_video_render_context(obs_core_video_mix_t *mix);
 
 /** Set the replay buffer rendering mode*/
@@ -1151,8 +1158,16 @@ EXPORT video_t *obs_view_add2(obs_view_t *view, struct obs_video_info *ovi);
  * retained canvas identity asynchronously on the video thread. The identified
  * canvas cannot be removed while that retention is active.
  *
- * @return The newly created auxiliary mix, or NULL if validation or creation
- *         failed.
+ * @param  view                 Non-NULL view whose sources the auxiliary mix
+ *                              renders. It must remain alive until the mix is
+ *                              removed with obs_view_remove().
+ * @param  render_info          Non-NULL private render settings copied into
+ *                              the auxiliary mix.
+ * @param  identity_source_mix  Non-NULL published ordinary mix whose
+ *                              registered canvas identity and rendering mode
+ *                              are borrowed.
+ * @return                      The newly created auxiliary mix, or NULL if
+ *                              validation or creation failed.
  */
 EXPORT obs_core_video_mix_t *
 obs_view_add_auxiliary_mix(obs_view_t *view,
@@ -2516,11 +2531,43 @@ EXPORT bool obs_weak_encoder_references_encoder(obs_weak_encoder_t *weak, obs_en
 EXPORT void obs_encoder_set_name(obs_encoder_t *encoder, const char *name);
 EXPORT const char *obs_encoder_get_name(const obs_encoder_t *encoder);
 
+/**
+ * Binds an encoder to a currently published video mix.
+ *
+ * The mix is borrowed and remains owned by libobs. Binding it does not extend
+ * its lifetime. For a video encoder, the encoder must be inactive and not yet
+ * initialized. A NULL or stale mix, an invalid encoder, or an active or
+ * initialized video encoder causes the request to be logged and ignored.
+ *
+ * @param  encoder  Encoder to bind. Audio encoders use the mix identity for
+ *                  canvas-aware audio routing.
+ * @param  video    Published video mix to bind.
+ */
 EXPORT void obs_encoder_set_video_mix(obs_encoder_t *encoder,
 				      struct obs_core_video_mix *video);
 
+/**
+ * Returns the video output owned by a video mix.
+ *
+ * The returned pointer is borrowed and remains valid only while @p mix is
+ * valid. No reference or ownership is transferred.
+ *
+ * @param  mix  Video mix to inspect, or NULL.
+ * @return      The mix's video output, or NULL when @p mix is NULL.
+ */
 EXPORT video_t *obs_video_mix_get_video(struct obs_core_video_mix *mix);
 
+/**
+ * Finds a published ordinary video mix by canvas identity and rendering mode.
+ *
+ * Auxiliary and encoder-only mixes are excluded from discovery. A NULL @p ovi
+ * matches any canvas identity. The returned handle is borrowed, transfers no
+ * ownership, and remains valid only while the mix stays published.
+ *
+ * @param  ovi   Registered canvas identity to match, or NULL as a wildcard.
+ * @param  mode  Rendering mode to match.
+ * @return       The first matching ordinary mix, or NULL when no match exists.
+ */
 EXPORT obs_core_video_mix_t *
 obs_video_mix_get(struct obs_video_info *ovi,
 		  enum obs_video_rendering_mode mode);

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -1125,8 +1125,10 @@ EXPORT video_t *obs_view_add2(obs_view_t *view, struct obs_video_info *ovi);
  *
  * The mix renders @p view using a copy of @p render_info. It uses the
  * registered video info and rendering mode from @p identity_source_mix for
- * canvas-specific scene filtering and audio routing. Encoder scaling also
- * preserves the frame rate specified by @p render_info.
+ * canvas-specific scene filtering and audio routing. All video mixes share the
+ * main graphics thread's render cadence, so @p render_info must specify a frame
+ * rate equivalent to @p identity_source_mix. Use an encoder frame-rate divisor
+ * when a lower output frame rate is required.
  *
  * @p identity_source_mix must be a valid mix returned by obs_video_mix_get()
  * whose view remains in the main render loop. Auxiliary mixes are not returned
@@ -1144,7 +1146,8 @@ EXPORT video_t *obs_view_add2(obs_view_t *view, struct obs_video_info *ovi);
  * @param  render_info          Non-NULL video settings, copied by value.
  * @param  identity_source_mix  Non-NULL source mix returned by
  *                              obs_video_mix_get().
- * @return                      The new auxiliary mix, or NULL on failure.
+ * @return                      The new auxiliary mix, or NULL if validation or
+ *                              creation fails.
  */
 EXPORT obs_core_video_mix_t *obs_view_add_auxiliary_mix(obs_view_t *view, const struct obs_video_info *render_info,
 							obs_core_video_mix_t *identity_source_mix);

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -465,8 +465,7 @@ EXPORT int obs_reset_video(struct obs_video_info *ovi);
 
 EXPORT int obs_deactivate_video_info();
 
-EXPORT int obs_set_video_info(struct obs_video_info *canvas,
-			      struct obs_video_info *updated);
+EXPORT int obs_set_video_info(struct obs_video_info *canvas, struct obs_video_info *updated);
 
 /** Gets video info first/default */
 EXPORT bool obs_get_video_info(struct obs_video_info *ovi);
@@ -474,19 +473,14 @@ EXPORT bool obs_get_video_info(struct obs_video_info *ovi);
 EXPORT bool obs_get_video_info_current(struct obs_video_info *ovi);
 /** Gets video info by index*/
 EXPORT size_t obs_get_video_info_count();
-EXPORT bool obs_get_video_info_by_index(size_t index,
-					struct obs_video_info *ovi);
-EXPORT struct obs_video_info * obs_get_video_info_by_index2(size_t index);
+EXPORT bool obs_get_video_info_by_index(size_t index, struct obs_video_info *ovi);
+EXPORT struct obs_video_info *obs_get_video_info_by_index2(size_t index);
 /** Gets video info used by output*/
-EXPORT bool obs_get_video_info_for_output(obs_output_t *output,
-					  struct obs_video_info *ovi,
-					  size_t index);
+EXPORT bool obs_get_video_info_for_output(obs_output_t *output, struct obs_video_info *ovi, size_t index);
 /** Gets video info used by output*/
-EXPORT bool obs_get_video_info_for_encoder(obs_encoder_t *encoder,
-					   struct obs_video_info *ovi);
+EXPORT bool obs_get_video_info_for_encoder(obs_encoder_t *encoder, struct obs_video_info *ovi);
 
-EXPORT bool obs_get_video_info_scene_item(obs_sceneitem_t *item,
-					  struct obs_video_info *ovi);
+EXPORT bool obs_get_video_info_scene_item(obs_sceneitem_t *item, struct obs_video_info *ovi);
 
 /**
  * Removes a video info created by obs_create_video_info().
@@ -494,7 +488,8 @@ EXPORT bool obs_get_video_info_scene_item(obs_sceneitem_t *item,
  * @return OBS_VIDEO_SUCCESS if successful
  *         OBS_VIDEO_INVALID_PARAM if the video info is not registered
  *         OBS_VIDEO_CURRENTLY_ACTIVE if video cannot be deactivated
- *         OBS_VIDEO_INFO_IN_USE if a scene item is assigned to the video info
+ *         OBS_VIDEO_INFO_IN_USE if a scene item or non-ordinary video mix
+ *             retains the video info
  *         OBS_VIDEO_REINITIALIZATION_FAILED if the video info was removed but
  *             the remaining video configuration could not be initialized
  *         OBS_VIDEO_FAIL for generic failure
@@ -916,8 +911,7 @@ EXPORT proc_handler_t *obs_get_proc_handler(void);
 EXPORT void obs_render_main_texture(void);
 
 /** Renders the output texture for a specific output*/
-EXPORT void obs_render_texture(struct obs_video_info *ovi,
-			       enum obs_video_rendering_mode mode);
+EXPORT void obs_render_texture(struct obs_video_info *ovi, enum obs_video_rendering_mode mode);
 
 /** Renders the last main output texture ignoring background color */
 EXPORT void obs_render_main_texture_src_color_only(void);
@@ -965,12 +959,10 @@ EXPORT void obs_set_audio_rendering_canvas(struct obs_video_info *ovi);
 EXPORT void obs_set_video_render_context(obs_core_video_mix_t *mix);
 
 /** Set the replay buffer rendering mode*/
-EXPORT void obs_set_replay_buffer_rendering_mode(
-	enum obs_replay_buffer_rendering_mode mode);
+EXPORT void obs_set_replay_buffer_rendering_mode(enum obs_replay_buffer_rendering_mode mode);
 
 /** Get current replay buffer rendering mode*/
-EXPORT enum obs_replay_buffer_rendering_mode
-obs_get_replay_buffer_rendering_mode(void);
+EXPORT enum obs_replay_buffer_rendering_mode obs_get_replay_buffer_rendering_mode(void);
 
 /** Saves a source to settings data */
 EXPORT obs_data_t *obs_save_source(obs_source_t *source);
@@ -1120,12 +1112,10 @@ EXPORT void obs_view_render(obs_view_t *view);
 EXPORT video_t *obs_view_add(obs_view_t *view);
 
 /** Adds a view to the main render loop */
-EXPORT video_t *obs_stream_view_add(obs_view_t *view,
-				    struct obs_video_info *ovi);
+EXPORT video_t *obs_stream_view_add(obs_view_t *view, struct obs_video_info *ovi);
 
 /** Adds a view to the main render loop */
-EXPORT video_t *obs_record_view_add(obs_view_t *view,
-				    struct obs_video_info *ovi);
+EXPORT video_t *obs_record_view_add(obs_view_t *view, struct obs_video_info *ovi);
 
 /** Adds a view to the main render loop, with custom video settings */
 EXPORT video_t *obs_view_add2(obs_view_t *view, struct obs_video_info *ovi);
@@ -1156,10 +1146,8 @@ EXPORT video_t *obs_view_add2(obs_view_t *view, struct obs_video_info *ovi);
  *                              obs_video_mix_get().
  * @return                      The new auxiliary mix, or NULL on failure.
  */
-EXPORT obs_core_video_mix_t *
-obs_view_add_auxiliary_mix(obs_view_t *view,
-			   const struct obs_video_info *render_info,
-			   obs_core_video_mix_t *identity_source_mix);
+EXPORT obs_core_video_mix_t *obs_view_add_auxiliary_mix(obs_view_t *view, const struct obs_video_info *render_info,
+							obs_core_video_mix_t *identity_source_mix);
 
 /** Removes a view from the main render loop */
 EXPORT void obs_view_remove(obs_view_t *view);
@@ -1183,12 +1171,10 @@ EXPORT obs_display_t *obs_display_create(const struct gs_init_data *graphics_dat
 EXPORT void obs_display_destroy(obs_display_t *display);
 
 /** Changes the size of this display */
-EXPORT void obs_display_resize(obs_display_t *display, uint32_t cx,
-			       uint32_t cy);
+EXPORT void obs_display_resize(obs_display_t *display, uint32_t cx, uint32_t cy);
 #ifdef __APPLE__
 /** Creates IOSurface (Apple shared memory) */
-EXPORT uint32_t obs_display_create_iosurface(obs_display_t *display,
-					     uint32_t width, uint32_t height);
+EXPORT uint32_t obs_display_create_iosurface(obs_display_t *display, uint32_t width, uint32_t height);
 #endif
 
 /** Updates the color space of this display */
@@ -1850,12 +1836,10 @@ EXPORT bool obs_transition_audio_render(obs_source_t *transition, uint64_t *ts_o
 					obs_transition_audio_mix_callback_t mix_a_callback,
 					obs_transition_audio_mix_callback_t mix_b_callback);
 
-EXPORT bool obs_transition_audio_render_do(
-	obs_source_t *transition, uint64_t *ts_out,
-	struct audio_data_mixes_outputs *audio, uint32_t mixers,
-	size_t channels, size_t sample_rate,
-	obs_transition_audio_mix_callback_t mix_a_callback,
-	obs_transition_audio_mix_callback_t mix_b_callback);
+EXPORT bool obs_transition_audio_render_do(obs_source_t *transition, uint64_t *ts_out,
+					   struct audio_data_mixes_outputs *audio, uint32_t mixers, size_t channels,
+					   size_t sample_rate, obs_transition_audio_mix_callback_t mix_a_callback,
+					   obs_transition_audio_mix_callback_t mix_b_callback);
 
 /* swaps transition sources and textures as an optimization and to reduce
  * memory usage when switching between transitions */
@@ -1976,11 +1960,9 @@ EXPORT bool obs_sceneitem_selected(const obs_sceneitem_t *item);
 EXPORT bool obs_sceneitem_locked(const obs_sceneitem_t *item);
 EXPORT bool obs_sceneitem_set_locked(obs_sceneitem_t *item, bool lock);
 EXPORT bool obs_sceneitem_stream_visible(const obs_sceneitem_t *item);
-EXPORT bool obs_sceneitem_set_stream_visible(obs_sceneitem_t *item,
-					     bool stream_visible);
+EXPORT bool obs_sceneitem_set_stream_visible(obs_sceneitem_t *item, bool stream_visible);
 EXPORT bool obs_sceneitem_recording_visible(const obs_sceneitem_t *item);
-EXPORT bool obs_sceneitem_set_recording_visible(obs_sceneitem_t *item,
-						bool recording_visible);
+EXPORT bool obs_sceneitem_set_recording_visible(obs_sceneitem_t *item, bool recording_visible);
 
 /* Functions for getting/setting specific orientation of a scene item */
 EXPORT void obs_sceneitem_set_pos(obs_sceneitem_t *item, const struct vec2 *pos);
@@ -1991,17 +1973,14 @@ EXPORT void obs_sceneitem_set_order(obs_sceneitem_t *item, enum obs_order_moveme
 EXPORT void obs_sceneitem_set_order_position(obs_sceneitem_t *item, int position);
 EXPORT void obs_sceneitem_set_bounds_type(obs_sceneitem_t *item, enum obs_bounds_type type);
 EXPORT void obs_sceneitem_set_bounds_alignment(obs_sceneitem_t *item, uint32_t alignment);
-EXPORT void obs_scene_set_items_order(obs_scene_t *scene,
-				      int64_t *new_items_order,
-				      int items_count);
+EXPORT void obs_scene_set_items_order(obs_scene_t *scene, int64_t *new_items_order, int items_count);
 EXPORT void obs_sceneitem_set_bounds_crop(obs_sceneitem_t *item, bool crop);
 EXPORT void obs_sceneitem_set_bounds(obs_sceneitem_t *item, const struct vec2 *bounds);
 
 EXPORT int64_t obs_sceneitem_get_id(const obs_sceneitem_t *item);
 
 EXPORT void obs_sceneitem_get_pos(const obs_sceneitem_t *item, struct vec2 *pos);
-EXPORT void obs_sceneitem_get_size(const obs_sceneitem_t *item,
-				   struct vec2 *size);
+EXPORT void obs_sceneitem_get_size(const obs_sceneitem_t *item, struct vec2 *size);
 EXPORT float obs_sceneitem_get_rot(const obs_sceneitem_t *item);
 EXPORT void obs_sceneitem_get_scale(const obs_sceneitem_t *item, struct vec2 *scale);
 EXPORT uint32_t obs_sceneitem_get_alignment(const obs_sceneitem_t *item);
@@ -2026,8 +2005,7 @@ EXPORT bool obs_sceneitem_set_visible(obs_sceneitem_t *item, bool visible);
  * item render on every canvas.  A non-NULL video info must remain registered;
  * attempts to assign a removed or currently-removing video info are ignored.
  */
-EXPORT void obs_sceneitem_set_canvas(obs_sceneitem_t *item,
-				     struct obs_video_info *canvas);
+EXPORT void obs_sceneitem_set_canvas(obs_sceneitem_t *item, struct obs_video_info *canvas);
 /** Returns a borrowed video info pointer kept alive by the scene item. */
 EXPORT struct obs_video_info *obs_sceneitem_get_canvas(obs_sceneitem_t *item);
 
@@ -2521,17 +2499,19 @@ EXPORT const char *obs_encoder_get_name(const obs_encoder_t *encoder);
 /**
  * Sets the video mix to be used with an encoder.
  *
- * @p video must be a valid mix owned by libobs. No reference is added, so the
- * mix must remain valid while the encoder uses it. A video encoder must be
- * inactive and not yet initialized. For an audio encoder, the mix selects the
- * registered video info used for canvas-specific audio rendering. Invalid
- * arguments or encoder state trigger a warning and leave the encoder unchanged.
+ * @p mix must be owned by libobs. No reference is added, so the mix must remain
+ * valid while the encoder uses it. The mix supplies a video encoder's input and
+ * selects the registered video info used to route an audio encoder to one
+ * canvas.
+ *
+ * A video encoder must be inactive and not yet initialized. An audio encoder
+ * must be inactive, but may already be initialized. A NULL or stale mix, or an
+ * invalid encoder state, triggers a warning and leaves the encoder unchanged.
  *
  * @param  encoder  Encoder to update.
- * @param  video    Non-NULL video mix to use.
+ * @param  mix      Non-NULL video mix to use.
  */
-EXPORT void obs_encoder_set_video_mix(obs_encoder_t *encoder,
-				      struct obs_core_video_mix *video);
+EXPORT void obs_encoder_set_video_mix(obs_encoder_t *encoder, struct obs_core_video_mix *mix);
 
 /**
  * Returns the video output context used by a video mix.
@@ -2556,9 +2536,7 @@ EXPORT video_t *obs_video_mix_get_video(struct obs_core_video_mix *mix);
  * @param  mode  Video rendering mode to match.
  * @return       First matching video mix, or NULL if none is found.
  */
-EXPORT obs_core_video_mix_t *
-obs_video_mix_get(struct obs_video_info *ovi,
-		  enum obs_video_rendering_mode mode);
+EXPORT obs_core_video_mix_t *obs_video_mix_get(struct obs_video_info *ovi, enum obs_video_rendering_mode mode);
 
 /** Returns the codec of an encoder by the id */
 EXPORT const char *obs_get_encoder_codec(const char *id);
@@ -2749,8 +2727,7 @@ EXPORT void *obs_encoder_create_rerouted(obs_encoder_t *encoder, const char *rer
 EXPORT bool obs_encoder_paused(const obs_encoder_t *output);
 
 /** Set encoder error to outputs */
-EXPORT void obs_outputs_set_last_error(obs_encoder_t *encoder,
-				       const char *error_text);
+EXPORT void obs_outputs_set_last_error(obs_encoder_t *encoder, const char *error_text);
 EXPORT const char *obs_encoder_get_last_error(obs_encoder_t *encoder);
 EXPORT void obs_encoder_set_last_error(obs_encoder_t *encoder, const char *message);
 
@@ -2901,7 +2878,8 @@ EXPORT enum obs_icon_type obs_source_get_icon_type(const char *id);
  * obs_output_add_packet_callback() and obs_output_remove_packet_callback(),
  * respectively.
  */
-EXPORT void bpm_inject(obs_output_t *output, struct encoder_packet *pkt, struct encoder_packet_time *pkt_time, void *param);
+EXPORT void bpm_inject(obs_output_t *output, struct encoder_packet *pkt, struct encoder_packet_time *pkt_time,
+		       void *param);
 
 /* BPM function to destroy all allocations for a given output. */
 EXPORT void bpm_destroy(obs_output_t *output);

--- a/plugins/obs-nvenc/nvenc-cuda.c
+++ b/plugins/obs-nvenc/nvenc-cuda.c
@@ -99,7 +99,7 @@ void cuda_ctx_free(struct nvenc_data *enc)
 
 static bool cuda_surface_init(struct nvenc_data *enc, struct nv_cuda_surface *nvsurf)
 {
-	const bool p010 = obs_encoder_video_tex_active(enc->encoder, VIDEO_FORMAT_P010);
+	const bool p010 = !enc->non_texture && obs_encoder_video_tex_active(enc->encoder, VIDEO_FORMAT_P010);
 	CUDA_ARRAY3D_DESCRIPTOR desc;
 	desc.Width = enc->cx;
 	desc.Height = enc->cy;


### PR DESCRIPTION
This change improves separation of concerns between a mix's render configuration, canvas identity, audio routing, and lifecycle semantics.

### Description
Adds auxiliary video mixes that render with private video settings while retaining an ordinary mix’s canvas identity for scene filtering and audio routing.

The change also introduces explicit ordinary, auxiliary, and encoder-only mix kinds; preserves auxiliary frame rates;and strengthens encoder pairing and mix teardown.

### Motivation and Context
Enhanced Broadcasting probes need to test candidate resolutions and frame rates without changing or registering additional application canvases. The previous model conflated render settings with canvas identity, which could prevent audio packets from reaching probe outputs and make concurrent mix cleanup unsafe.

This is the libobs portion of the coordinated OSN Auto Optimizer implementation. OSN creates auxiliary mixes for temporary Enhanced Broadcasting workloads, uses their handles directly, stops attached outputs, and then removes the mixes.

### Additional fix

This branch also fixes a crash when initializing standalone raw-input NVENC encoders. CUDA surface setup previously queried texture-backed video-mix state even for non-texture encoders, which may not have an assigned video mix. The query is now limited to texture encoders, and the underlying helper safely handles missing encoder media or mix state. The issue persists in the upstream OBS.

### How Has This Been Tested?
Windows only.
Manual testing + 
A lot of tests in `obs-studio-node`.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality) 
- Tweak (non-breaking change to improve existing functionality)