### PR TITLE
Fix monitoring deduplication source lifetime

### DIFF
--- a/libobs/obs-audio.c
+++ b/libobs/obs-audio.c
@@ -538,34 +538,31 @@ static inline void execute_audio_tasks(void)
 /* In case monitoring and an 'Audio Output Capture' source have the same device, one silences all the monitored
  * sources unless the 'Audio Output Capture' is muted.
  */
-static inline bool should_silence_monitored_source(obs_source_t *source, struct obs_core_audio *audio)
+static inline bool should_silence_monitored_source(obs_source_t *source, obs_source_t *dup_src)
 {
-	obs_source_t *dup_src = audio->monitoring_duplicating_source;
-
 	if (!dup_src || !obs_source_active(dup_src))
 		return false;
 
 	if (dup_src->monitoring_type == OBS_MONITORING_TYPE_MONITOR_ONLY)
 		return false;
 
-	bool fader_muted = close_float(audio->monitoring_duplicating_source->volume, 0.0f, 0.0001f);
-	bool output_capture_unmuted = !audio->monitoring_duplicating_source->muted && !fader_muted;
+	bool fader_muted = close_float(dup_src->volume, 0.0f, 0.0001f);
+	bool output_capture_unmuted = !dup_src->muted && !fader_muted;
 
 	if (output_capture_unmuted) {
-		if (source->monitoring_type == OBS_MONITORING_TYPE_MONITOR_AND_OUTPUT &&
-		    source != audio->monitoring_duplicating_source) {
+		if (source->monitoring_type == OBS_MONITORING_TYPE_MONITOR_AND_OUTPUT && source != dup_src) {
 			return true;
 		}
 	}
 	return false;
 }
 
-static inline void clear_audio_output_buf(obs_source_t *source, struct obs_core_audio *audio)
+static inline void clear_audio_output_buf(obs_source_t *source, obs_source_t *dup_src)
 {
-	if (!audio->monitoring_duplicating_source)
+	if (!dup_src)
 		return;
 
-	uint32_t aoc_mixers = audio->monitoring_duplicating_source->audio_mixers;
+	uint32_t aoc_mixers = dup_src->audio_mixers;
 	uint32_t source_mixers = source->audio_mixers;
 
 	for (size_t mix = 0; mix < MAX_AUDIO_MIXES; mix++) {
@@ -662,11 +659,15 @@ bool audio_callback(void *param, uint64_t start_ts_in, uint64_t end_ts_in, uint6
 
 	/* ------------------------------------------------ */
 	/* render audio data */
+	pthread_mutex_lock(&audio->monitoring_mutex);
+	obs_source_t *dup_src = obs_weak_source_get_source(audio->monitoring_duplicating_source);
+	pthread_mutex_unlock(&audio->monitoring_mutex);
+
 	for (size_t i = 0; i < audio->render_order.num; i++) {
 		obs_source_t *source = audio->render_order.array[i];
 		obs_source_audio_render(source, mixers, channels, sample_rate, audio_size);
-		if (should_silence_monitored_source(source, audio))
-			clear_audio_output_buf(source, audio);
+		if (should_silence_monitored_source(source, dup_src))
+			clear_audio_output_buf(source, dup_src);
 
 		/* if a source has gone backward in time and we can no
 		 * longer buffer, drop some or all of its audio */
@@ -694,6 +695,7 @@ bool audio_callback(void *param, uint64_t start_ts_in, uint64_t end_ts_in, uint6
 			}
 		}
 	}
+	obs_source_release(dup_src);
 
 	/* ------------------------------------------------ */
 	/* get minimum audio timestamp */

--- a/libobs/obs-audio.c
+++ b/libobs/obs-audio.c
@@ -659,9 +659,10 @@ bool audio_callback(void *param, uint64_t start_ts_in, uint64_t end_ts_in, uint6
 
 	/* ------------------------------------------------ */
 	/* render audio data */
-	pthread_mutex_lock(&audio->monitoring_deduplication_mutex);
-	obs_source_t *dup_src = obs_weak_source_get_source(audio->monitoring_duplicating_source);
-	pthread_mutex_unlock(&audio->monitoring_deduplication_mutex);
+	struct obs_monitoring_deduplication *deduplication = &obs->monitoring_deduplication;
+	pthread_mutex_lock(&deduplication->mutex);
+	obs_source_t *dup_src = obs_weak_source_get_source(deduplication->source);
+	pthread_mutex_unlock(&deduplication->mutex);
 
 	for (size_t i = 0; i < audio->render_order.num; i++) {
 		obs_source_t *source = audio->render_order.array[i];

--- a/libobs/obs-audio.c
+++ b/libobs/obs-audio.c
@@ -659,9 +659,9 @@ bool audio_callback(void *param, uint64_t start_ts_in, uint64_t end_ts_in, uint6
 
 	/* ------------------------------------------------ */
 	/* render audio data */
-	pthread_mutex_lock(&audio->monitoring_mutex);
+	pthread_mutex_lock(&audio->monitoring_deduplication_mutex);
 	obs_source_t *dup_src = obs_weak_source_get_source(audio->monitoring_duplicating_source);
-	pthread_mutex_unlock(&audio->monitoring_mutex);
+	pthread_mutex_unlock(&audio->monitoring_deduplication_mutex);
 
 	for (size_t i = 0; i < audio->render_order.num; i++) {
 		obs_source_t *source = audio->render_order.array[i];

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -503,7 +503,7 @@ struct obs_core_audio {
 	pthread_mutex_t task_mutex;
 	struct deque tasks;
 
-	struct obs_source *monitoring_duplicating_source;
+	obs_weak_source_t *monitoring_duplicating_source;
 };
 
 /* user sources, output channels, and displays */

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -502,10 +502,13 @@ struct obs_core_audio {
 
 	pthread_mutex_t task_mutex;
 	struct deque tasks;
+};
 
-	/* Kept separate from monitoring_mutex, which can cover device reset. */
-	pthread_mutex_t monitoring_deduplication_mutex;
-	obs_weak_source_t *monitoring_duplicating_source;
+struct obs_monitoring_deduplication {
+	/* Source-lifetime state that must survive audio output resets. */
+	pthread_mutex_t mutex;
+	obs_weak_source_t *source;
+	bool mutex_initialized;
 };
 
 /* user sources, output channels, and displays */
@@ -619,6 +622,7 @@ struct obs_core {
 	 * clean and organized */
 	struct obs_core_video video;
 	struct obs_core_audio audio;
+	struct obs_monitoring_deduplication monitoring_deduplication;
 	struct obs_core_data data;
 	struct obs_core_hotkeys hotkeys;
 

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -503,6 +503,8 @@ struct obs_core_audio {
 	pthread_mutex_t task_mutex;
 	struct deque tasks;
 
+	/* Kept separate from monitoring_mutex, which can cover device reset. */
+	pthread_mutex_t monitoring_deduplication_mutex;
 	obs_weak_source_t *monitoring_duplicating_source;
 };
 

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -399,6 +399,39 @@ void obs_source_audio_output_capture_device_activated(void *vptr, calldata_t *cd
 }
 
 extern bool devices_match(const char *id1, const char *id2);
+
+static void set_monitoring_duplication_source(obs_source_t *source)
+{
+	struct obs_core_audio *audio = &obs->audio;
+	obs_weak_source_t *weak_source = obs_source_get_weak_source(source);
+	obs_weak_source_t *old_source;
+
+	pthread_mutex_lock(&audio->monitoring_mutex);
+	old_source = audio->monitoring_duplicating_source;
+	audio->monitoring_duplicating_source = weak_source;
+	pthread_mutex_unlock(&audio->monitoring_mutex);
+
+	obs_weak_source_release(old_source);
+}
+
+static bool clear_monitoring_duplication_source(obs_source_t *source)
+{
+	struct obs_core_audio *audio = &obs->audio;
+	obs_weak_source_t *old_source = NULL;
+	bool cleared = false;
+
+	pthread_mutex_lock(&audio->monitoring_mutex);
+	if (obs_weak_source_references_source(audio->monitoring_duplicating_source, source)) {
+		old_source = audio->monitoring_duplicating_source;
+		audio->monitoring_duplicating_source = NULL;
+		cleared = true;
+	}
+	pthread_mutex_unlock(&audio->monitoring_mutex);
+
+	obs_weak_source_release(old_source);
+	return cleared;
+}
+
 void obs_source_audio_output_capture_device_changed(obs_source_t *src, const char *device_id)
 {
 	struct obs_core_audio *audio = &obs->audio;
@@ -426,27 +459,18 @@ void obs_source_audio_output_capture_device_changed(obs_source_t *src, const cha
 #else
 	id_match = devices_match(device_id, mon_id);
 #endif
-	struct calldata cd;
-	uint8_t stack[128];
-	calldata_init_fixed(&cd, stack, sizeof(stack));
-
 	if (id_match) {
-		calldata_set_ptr(&cd, "source", src);
-		signal_handler_signal(obs->signals, "deduplication_changed", &cd);
+		set_monitoring_duplication_source(src);
 		signal_handler_connect(src->context.signals, "activate",
 				       obs_source_audio_output_capture_device_activated, NULL);
 		blog(LOG_INFO,
 		     "Device for 'Audio Output Capture' source %s is also used for audio monitoring."
 		     "\nDeduplication logic is being applied to all monitored sources.",
 		     src->context.name);
-	} else {
-		if (src == audio->monitoring_duplicating_source) {
-			calldata_set_ptr(&cd, "source", NULL);
-			signal_handler_disconnect(src->context.signals, "activate",
-						  obs_source_audio_output_capture_device_activated, NULL);
-			signal_handler_signal(obs->signals, "deduplication_changed", &cd);
-			blog(LOG_INFO, "Deduplication logic stopped.");
-		}
+	} else if (clear_monitoring_duplication_source(src)) {
+		signal_handler_disconnect(src->context.signals, "activate",
+					  obs_source_audio_output_capture_device_activated, NULL);
+		blog(LOG_INFO, "Deduplication logic stopped.");
 	}
 }
 

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -402,31 +402,31 @@ extern bool devices_match(const char *id1, const char *id2);
 
 static void set_monitoring_duplication_source(obs_source_t *source)
 {
-	struct obs_core_audio *audio = &obs->audio;
+	struct obs_monitoring_deduplication *deduplication = &obs->monitoring_deduplication;
 	obs_weak_source_t *weak_source = obs_source_get_weak_source(source);
 	obs_weak_source_t *old_source;
 
-	pthread_mutex_lock(&audio->monitoring_deduplication_mutex);
-	old_source = audio->monitoring_duplicating_source;
-	audio->monitoring_duplicating_source = weak_source;
-	pthread_mutex_unlock(&audio->monitoring_deduplication_mutex);
+	pthread_mutex_lock(&deduplication->mutex);
+	old_source = deduplication->source;
+	deduplication->source = weak_source;
+	pthread_mutex_unlock(&deduplication->mutex);
 
 	obs_weak_source_release(old_source);
 }
 
 static bool clear_monitoring_duplication_source(obs_source_t *source)
 {
-	struct obs_core_audio *audio = &obs->audio;
+	struct obs_monitoring_deduplication *deduplication = &obs->monitoring_deduplication;
 	obs_weak_source_t *old_source = NULL;
 	bool cleared = false;
 
-	pthread_mutex_lock(&audio->monitoring_deduplication_mutex);
-	if (obs_weak_source_references_source(audio->monitoring_duplicating_source, source)) {
-		old_source = audio->monitoring_duplicating_source;
-		audio->monitoring_duplicating_source = NULL;
+	pthread_mutex_lock(&deduplication->mutex);
+	if (obs_weak_source_references_source(deduplication->source, source)) {
+		old_source = deduplication->source;
+		deduplication->source = NULL;
 		cleared = true;
 	}
-	pthread_mutex_unlock(&audio->monitoring_deduplication_mutex);
+	pthread_mutex_unlock(&deduplication->mutex);
 
 	obs_weak_source_release(old_source);
 	return cleared;
@@ -436,10 +436,19 @@ void obs_source_audio_output_capture_device_changed(obs_source_t *src, const cha
 {
 	struct obs_core_audio *audio = &obs->audio;
 
-	if (!audio->monitoring_device_name)
+	if (!(src->info.output_flags & OBS_SOURCE_DO_NOT_SELF_MONITOR))
 		return;
 
-	if (!(src->info.output_flags & OBS_SOURCE_DO_NOT_SELF_MONITOR))
+	if (!device_id) {
+		if (clear_monitoring_duplication_source(src)) {
+			signal_handler_disconnect(src->context.signals, "activate",
+					  obs_source_audio_output_capture_device_activated, NULL);
+			blog(LOG_INFO, "Deduplication logic stopped.");
+		}
+		return;
+	}
+
+	if (!audio->monitoring_device_name)
 		return;
 
 	const char *mon_id = audio->monitoring_device_id;

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -406,10 +406,10 @@ static void set_monitoring_duplication_source(obs_source_t *source)
 	obs_weak_source_t *weak_source = obs_source_get_weak_source(source);
 	obs_weak_source_t *old_source;
 
-	pthread_mutex_lock(&audio->monitoring_mutex);
+	pthread_mutex_lock(&audio->monitoring_deduplication_mutex);
 	old_source = audio->monitoring_duplicating_source;
 	audio->monitoring_duplicating_source = weak_source;
-	pthread_mutex_unlock(&audio->monitoring_mutex);
+	pthread_mutex_unlock(&audio->monitoring_deduplication_mutex);
 
 	obs_weak_source_release(old_source);
 }
@@ -420,13 +420,13 @@ static bool clear_monitoring_duplication_source(obs_source_t *source)
 	obs_weak_source_t *old_source = NULL;
 	bool cleared = false;
 
-	pthread_mutex_lock(&audio->monitoring_mutex);
+	pthread_mutex_lock(&audio->monitoring_deduplication_mutex);
 	if (obs_weak_source_references_source(audio->monitoring_duplicating_source, source)) {
 		old_source = audio->monitoring_duplicating_source;
 		audio->monitoring_duplicating_source = NULL;
 		cleared = true;
 	}
-	pthread_mutex_unlock(&audio->monitoring_mutex);
+	pthread_mutex_unlock(&audio->monitoring_deduplication_mutex);
 
 	obs_weak_source_release(old_source);
 	return cleared;

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -1109,22 +1109,6 @@ static void obs_free_graphics(void)
 	}
 }
 
-void set_monitoring_duplication_source(void *param)
-{
-	obs_source_t *src = param;
-	struct obs_core_audio *audio = &obs->audio;
-
-	audio->monitoring_duplicating_source = src;
-}
-
-static void apply_monitoring_deduplication(void *ignored, calldata_t *cd)
-{
-	UNUSED_PARAMETER(ignored);
-	obs_source_t *src = calldata_ptr(cd, "source");
-
-	obs_queue_task(OBS_TASK_AUDIO, set_monitoring_duplication_source, src, false);
-}
-
 static void set_audio_thread(void *unused);
 
 // The old audio object is returned to allow the caller to finalize it properly.
@@ -1176,9 +1160,6 @@ static bool obs_init_audio(struct audio_output_info *ai)
 	ai->input_param = audio;
 	audio->monitoring_duplicating_source = NULL;
 
-	signal_handler_add(obs->signals, "void deduplication_changed(ptr source)");
-	signal_handler_connect(obs->signals, "deduplication_changed", apply_monitoring_deduplication, NULL);
-
 	errorcode = audio_output_open(&audio_output, ai);
 	if (errorcode == AUDIO_OUTPUT_SUCCESS) {
 		obs_set_audio_output(audio_output);
@@ -1224,6 +1205,9 @@ static void obs_free_audio(void)
 
 	if (old_audio)
 		audio_output_close(old_audio);
+
+	obs_weak_source_release(audio->monitoring_duplicating_source);
+	audio->monitoring_duplicating_source = NULL;
 
 	deque_free(&audio->buffered_timestamps);
 	da_free(audio->render_order);

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -1136,15 +1136,20 @@ static bool obs_init_audio(struct audio_output_info *ai)
 	struct obs_core_audio *audio = &obs->audio;
 	audio_t *audio_output = NULL;
 	bool monitoring_mutex_initialized = false;
+	bool monitoring_deduplication_mutex_initialized = false;
 	bool task_mutex_initialized = false;
 	int errorcode;
 
 	pthread_mutex_init_value(&audio->monitoring_mutex);
+	pthread_mutex_init_value(&audio->monitoring_deduplication_mutex);
 	pthread_mutex_init_value(&audio->task_mutex);
 
 	if (pthread_mutex_init_recursive(&audio->monitoring_mutex) != 0)
 		goto fail;
 	monitoring_mutex_initialized = true;
+	if (pthread_mutex_init(&audio->monitoring_deduplication_mutex, NULL) != 0)
+		goto fail;
+	monitoring_deduplication_mutex_initialized = true;
 	if (pthread_mutex_init(&audio->task_mutex, NULL) != 0)
 		goto fail;
 	task_mutex_initialized = true;
@@ -1183,6 +1188,10 @@ fail:
 		pthread_mutex_destroy(&audio->task_mutex);
 		pthread_mutex_init_value(&audio->task_mutex);
 	}
+	if (monitoring_deduplication_mutex_initialized) {
+		pthread_mutex_destroy(&audio->monitoring_deduplication_mutex);
+		pthread_mutex_init_value(&audio->monitoring_deduplication_mutex);
+	}
 	if (monitoring_mutex_initialized) {
 		pthread_mutex_destroy(&audio->monitoring_mutex);
 		pthread_mutex_init_value(&audio->monitoring_mutex);
@@ -1218,6 +1227,7 @@ static void obs_free_audio(void)
 	bfree(audio->monitoring_device_id);
 	deque_free(&audio->tasks);
 	pthread_mutex_destroy(&audio->task_mutex);
+	pthread_mutex_destroy(&audio->monitoring_deduplication_mutex);
 	pthread_mutex_destroy(&audio->monitoring_mutex);
 
 	memset(audio, 0, sizeof(struct obs_core_audio));
@@ -1509,6 +1519,7 @@ static bool obs_init(const char *locale, const char *module_config_path, profile
 	obs = bzalloc(sizeof(struct obs_core));
 
 	pthread_mutex_init_value(&obs->audio.monitoring_mutex);
+	pthread_mutex_init_value(&obs->audio.monitoring_deduplication_mutex);
 	pthread_mutex_init_value(&obs->audio.task_mutex);
 	pthread_mutex_init_value(&obs->video.task_mutex);
 	pthread_mutex_init_value(&obs->video.encoder_group_mutex);

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -1111,6 +1111,35 @@ static void obs_free_graphics(void)
 
 static void set_audio_thread(void *unused);
 
+static void obs_clear_monitoring_duplication_source(void)
+{
+	struct obs_monitoring_deduplication *deduplication = &obs->monitoring_deduplication;
+	obs_weak_source_t *source = NULL;
+
+	if (!deduplication->mutex_initialized)
+		return;
+
+	pthread_mutex_lock(&deduplication->mutex);
+	source = deduplication->source;
+	deduplication->source = NULL;
+	pthread_mutex_unlock(&deduplication->mutex);
+
+	obs_weak_source_release(source);
+}
+
+static void obs_free_monitoring_deduplication(void)
+{
+	struct obs_monitoring_deduplication *deduplication = &obs->monitoring_deduplication;
+
+	if (!deduplication->mutex_initialized)
+		return;
+
+	obs_clear_monitoring_duplication_source();
+	pthread_mutex_destroy(&deduplication->mutex);
+	pthread_mutex_init_value(&deduplication->mutex);
+	deduplication->mutex_initialized = false;
+}
+
 // The old audio object is returned to allow the caller to finalize it properly.
 static audio_t *obs_clear_audio_output(void)
 {
@@ -1136,20 +1165,15 @@ static bool obs_init_audio(struct audio_output_info *ai)
 	struct obs_core_audio *audio = &obs->audio;
 	audio_t *audio_output = NULL;
 	bool monitoring_mutex_initialized = false;
-	bool monitoring_deduplication_mutex_initialized = false;
 	bool task_mutex_initialized = false;
 	int errorcode;
 
 	pthread_mutex_init_value(&audio->monitoring_mutex);
-	pthread_mutex_init_value(&audio->monitoring_deduplication_mutex);
 	pthread_mutex_init_value(&audio->task_mutex);
 
 	if (pthread_mutex_init_recursive(&audio->monitoring_mutex) != 0)
 		goto fail;
 	monitoring_mutex_initialized = true;
-	if (pthread_mutex_init(&audio->monitoring_deduplication_mutex, NULL) != 0)
-		goto fail;
-	monitoring_deduplication_mutex_initialized = true;
 	if (pthread_mutex_init(&audio->task_mutex, NULL) != 0)
 		goto fail;
 	task_mutex_initialized = true;
@@ -1163,7 +1187,6 @@ static bool obs_init_audio(struct audio_output_info *ai)
 	audio->speakers = ai->speakers;
 	audio->channels = get_audio_channels(ai->speakers);
 	ai->input_param = audio;
-	audio->monitoring_duplicating_source = NULL;
 
 	errorcode = audio_output_open(&audio_output, ai);
 	if (errorcode == AUDIO_OUTPUT_SUCCESS) {
@@ -1183,14 +1206,11 @@ fail:
 	audio->samples_per_sec = 0;
 	audio->speakers = SPEAKERS_UNKNOWN;
 	audio->channels = 0;
+	obs_clear_monitoring_duplication_source();
 
 	if (task_mutex_initialized) {
 		pthread_mutex_destroy(&audio->task_mutex);
 		pthread_mutex_init_value(&audio->task_mutex);
-	}
-	if (monitoring_deduplication_mutex_initialized) {
-		pthread_mutex_destroy(&audio->monitoring_deduplication_mutex);
-		pthread_mutex_init_value(&audio->monitoring_deduplication_mutex);
 	}
 	if (monitoring_mutex_initialized) {
 		pthread_mutex_destroy(&audio->monitoring_mutex);
@@ -1215,8 +1235,7 @@ static void obs_free_audio(void)
 	if (old_audio)
 		audio_output_close(old_audio);
 
-	obs_weak_source_release(audio->monitoring_duplicating_source);
-	audio->monitoring_duplicating_source = NULL;
+	obs_clear_monitoring_duplication_source();
 
 	deque_free(&audio->buffered_timestamps);
 	da_free(audio->render_order);
@@ -1227,7 +1246,6 @@ static void obs_free_audio(void)
 	bfree(audio->monitoring_device_id);
 	deque_free(&audio->tasks);
 	pthread_mutex_destroy(&audio->task_mutex);
-	pthread_mutex_destroy(&audio->monitoring_deduplication_mutex);
 	pthread_mutex_destroy(&audio->monitoring_mutex);
 
 	memset(audio, 0, sizeof(struct obs_core_audio));
@@ -1519,8 +1537,8 @@ static bool obs_init(const char *locale, const char *module_config_path, profile
 	obs = bzalloc(sizeof(struct obs_core));
 
 	pthread_mutex_init_value(&obs->audio.monitoring_mutex);
-	pthread_mutex_init_value(&obs->audio.monitoring_deduplication_mutex);
 	pthread_mutex_init_value(&obs->audio.task_mutex);
+	pthread_mutex_init_value(&obs->monitoring_deduplication.mutex);
 	pthread_mutex_init_value(&obs->video.task_mutex);
 	pthread_mutex_init_value(&obs->video.encoder_group_mutex);
 	pthread_mutex_init_value(&obs->video.mixes_mutex);
@@ -1565,6 +1583,10 @@ static bool obs_init(const char *locale, const char *module_config_path, profile
 	obs->audio_rendering_mode = OBS_MAIN_AUDIO_RENDERING;
 
 	da_init(obs->video.canvases);
+
+	if (pthread_mutex_init(&obs->monitoring_deduplication.mutex, NULL) != 0)
+		return false;
+	obs->monitoring_deduplication.mutex_initialized = true;
 
 	return true;
 }
@@ -1749,6 +1771,7 @@ void obs_shutdown(void)
 	obs_free_audio();
 	obs_free_video(true);
 	os_task_queue_destroy(obs->destruction_task_thread);
+	obs_free_monitoring_deduplication();
 	obs_free_hotkeys();
 	obs_free_graphics();
 	proc_handler_destroy(obs->procs);

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -1511,8 +1511,8 @@ EXPORT void obs_source_remove_audio_capture_callback(obs_source_t *source, obs_s
 
 /**
  * For an Audio Output Capture source (like 'wasapi_output_capture') used for 'Desktop Audio', this checks whether the
- * device is also used for monitoring. A signal to obs core struct is then emitted to trigger deduplication  logic at
- * the end of an audio tick.
+ * device is also used for monitoring. The core retains a weak reference to the matching source, and the audio callback
+ * retains a snapshot while applying deduplication for each tick.
  */
 EXPORT void obs_source_audio_output_capture_device_changed(obs_source_t *source, const char *device_id);
 


### PR DESCRIPTION
### Description
Fixes a use-after-free in audio monitoring deduplication using a synchronized weak reference and per-tick retained snapshot. Helper signatures now accept that snapshot to ensure consistent, lifetime-safe access.

The issue was reproduced locally by executing the same test multiple times.

### Motivation and Context
Monitoring deduplication asynchronously published a raw Audio Output Capture source pointer without retaining its lifetime. If the source was destroyed before the queued task ran (or before clearing completed) audio_callback could dereference freed memory.

The deduplication state now owns a weak source reference. Set and identity-conditional clear operations are serialized, while `audio_callback` promotes the weak reference to one strong snapshot for the complete render loop and releases it afterward. Audio shutdown also releases any remaining weak reference.

A dedicated deduplication mutex is used instead of `monitoring_mutex`. The latter can be held while monitoring devices are rebuilt, so using it from the real-time audio callback could block audio behind slow device initialization.

**The internal APIs of `should_silence_monitored_source` and `clear_audio_output_buf` intentionally changed from accepting `obs_core_audio` to accepting the promoted `obs_source_t` snapshot.** This ensures that:

- Both helpers use the same retained, live source for the entire audio tick.
- They cannot re-read mutable shared state after the mutex is released.
- The silence decision, identity comparison, and mixer selection cannot observe different sources.
- The mutex and reference promotion occur once per tick rather than once per rendered source.

### How Has This Been Tested?
Manually + multiple test runs reproduction on Windows

### Types of changes
- Bug fix (non-breaking change which fixes an issue) 